### PR TITLE
feat: add platform id

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/mercadopago.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mercadopago.rs
@@ -81,7 +81,12 @@ impl ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, Pay
         req: &hyperswitch_domain_models::types::TokenizationRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
+        let mut headers = self.build_headers(req, connectors)?;
+        headers.push((
+            "x-platform-id".to_string(),
+            masking::Secret::new(PXSOL_PLATFORM_ID.to_string()).into_masked(),
+        ));
+        Ok(headers)
     }
 
     fn get_content_type(&self) -> &'static str {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds platform identification to Mercado Pago API integration by introducing an `x-platform-id` header to payment requests. The changes specifically enhance the PaymentMethodToken (tokenization) and Authorize payment flows.

## Technical Changes

### Platform ID Implementation
- Introduces a module-level constant `PXSOL_PLATFORM_ID` with a hardcoded development identifier: `"dev_ab8e21775bb211ed88d80242ac130004"`
- Modified the `get_headers` method for `ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>` to append the `x-platform-id` header with the platform ID value
- Modified the `get_headers` method for `ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData>` to include the same platform ID header alongside existing idempotency and fraud detection headers
- Both implementations properly wrap the platform ID using `masking::Secret::new().into_masked()` to protect the value from exposure in logs

### Affected Flows
- **Tokenization Flow**: Card token creation (`POST /v1/card_tokens`)
- **Authorization Flow**: Payment authorization (`POST /v1/payments`) with support for idempotency keys and device-based anti-fraud tracking

## Security Considerations

**Positive Aspects:**
- Proper use of masking utility to prevent credential leakage in logs, consistent with the codebase's security practices
- Sensitive data handling aligns with existing patterns

**Concerns:**
- Platform ID is hardcoded as a development identifier rather than being configuration-driven through environment variables or connector configuration
- This approach may complicate environment-specific deployments (development, staging, production)

## Performance Impact
Negligible - only adds header construction overhead, which is minimal and non-blocking.

## Integration Status
The implementation is targeted at the Mercado Pago connector integration status marked as "Sandbox," indicating this feature supports the sandbox environment integration.

## Missing Elements
- No environment variable configuration mechanism; relies on code-level hardcoded value
- Test coverage for the new header functionality is not evident in the provided context
- No documentation or migration notes for existing integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->