### PR TITLE
feat: add marketplace mp commision

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -617,6 +617,11 @@ impl FloatMajorUnit {
         Self(0.0)
     }
 
+    /// gets amount as f64 value
+    pub fn get_amount_as_f64(self) -> f64 {
+        self.0
+    }
+
     /// converts to minor unit as i64 from FloatMajorUnit
     fn to_minor_unit_as_i64(
         self,

--- a/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
@@ -20,6 +20,8 @@ use crate::{
     utils::{self, RouterData as _},
 };
 
+const MAX_APPLICATION_FEE_RATIO: f64 = 0.005;
+
 pub struct MercadopagoRouterData<T> {
     pub amount: FloatMajorUnit,
     pub router_data: T,
@@ -101,6 +103,9 @@ pub struct MercadopagoMetadata {
     /// Device ID from Mercado Pago SDK for anti-fraud (X-meli-session-id header)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_id: Option<Secret<String>>,
+    /// Marketplace commission — absolute amount in the transaction currency
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub application_fee: Option<f64>,
 }
 
 impl TryFrom<&Option<SecretSerdeValue>> for MercadopagoMetadata {
@@ -339,6 +344,8 @@ pub struct MercadopagoPaymentsRequest {
     pub statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_info: Option<MercadopagoAdditionalInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub application_fee: Option<f64>,
 }
 
 impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for MercadopagoPaymentsRequest {
@@ -491,6 +498,21 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
             }
         };
 
+        let application_fee = match metadata.application_fee {
+            Some(fee) if fee > 0.0 => {
+                let amount_f64 = transaction_amount.get_amount_as_f64();
+                let max_fee = amount_f64 * MAX_APPLICATION_FEE_RATIO;
+                if fee > max_fee {
+                    return Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "application_fee exceeds maximum allowed (0.5% of transaction_amount)",
+                    }
+                    .into());
+                }
+                Some(fee)
+            }
+            _ => None,
+        };
+
         Ok(Self {
             transaction_amount,
             token,
@@ -510,6 +532,7 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
             notification_url,
             statement_descriptor: router_data.request.statement_descriptor.clone(),
             additional_info,
+            application_fee,
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

This PR adds marketplace commission (application fee) support to the MercadoPago connector, enabling merchants to apply commission fees on transactions in compliance with MercadoPago's fee limitations.

## Detailed Changes

### 1. Common Utils Enhancement (`crates/common_utils/src/types.rs`)
- Added public accessor method `get_amount_as_f64()` to the `FloatMajorUnit` struct that provides direct access to the underlying f64 value
- This method enables controlled access to the internal float representation while maintaining encapsulation

### 2. MercadoPago Transformer Enhancement (`crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs`)
- Introduced `MAX_APPLICATION_FEE_RATIO` constant set to 0.005 (0.5%) to enforce MercadoPago's maximum commission limit
- Extended `MercadopagoMetadata` struct with optional `application_fee: Option<f64>` field to capture marketplace commission metadata
- Extended `MercadopagoPaymentsRequest` struct with optional `application_fee: Option<f64>` field to include the fee in API requests
- Implemented validation logic during request transformation:
  - Accepts positive application fees
  - Validates that fees do not exceed 0.5% of the transaction amount
  - Returns `InvalidDataFormat` connector error with descriptive message if validation fails
  - Gracefully handles null or zero fees by setting the field to None

## Architectural Impacts
- **Extensibility**: The accessor method pattern enables future refactoring of the amount handling without breaking external consumers
- **Separation of Concerns**: Validation is properly placed in the transformer layer, maintaining single responsibility
- **Backwards Compatibility**: Optional fields ensure existing code paths remain unaffected
- **Marketplace Support**: Enables hyperswitch to function as a marketplace platform through MercadoPago

## Security Considerations
- **Fee Validation**: The 0.5% maximum ratio prevents merchants from charging excessive commissions
- **Input Validation**: Proper error handling with descriptive messages for invalid fee amounts
- **Safe Deserialization**: Optional field handling with fallback to None ensures robustness against malformed metadata

## Performance Implications
- **Minimal Overhead**: Validation involves only a single float multiplication and comparison operation
- **No Database Impact**: Changes are purely in-memory transformations with no schema modifications
- **Optional Fields**: Conditional fee processing only executes when metadata is provided
- **Efficient Serialization**: Use of `skip_serializing_if` attribute prevents unnecessary null fields in API requests

## Testing Gaps
No test files were identified in the provided changes. Unit tests for fee validation edge cases (boundary values, negative fees, zero fees) should be added to ensure correctness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PXSOL/hyperswitch/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->