### PR TITLE
fix(mercadopago): raise application_fee cap to 0.7%

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
@@ -20,7 +20,7 @@ use crate::{
     utils::{self, RouterData as _},
 };
 
-const MAX_APPLICATION_FEE_RATIO: f64 = 0.005;
+const MAX_APPLICATION_FEE_RATIO: f64 = 0.007;
 
 pub struct MercadopagoRouterData<T> {
     pub amount: FloatMajorUnit,
@@ -504,7 +504,7 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
                 let max_fee = amount_f64 * MAX_APPLICATION_FEE_RATIO;
                 if fee > max_fee {
                     return Err(errors::ConnectorError::InvalidDataFormat {
-                        field_name: "application_fee exceeds maximum allowed (0.5% of transaction_amount)",
+                        field_name: "application_fee exceeds maximum allowed (0.7% of transaction_amount)",
                     }
                     .into());
                 }


### PR DESCRIPTION
## Problem

Every MercadoPago v2 charge with commission enabled was failing with a `400 Bad Request`:

```
application_fee exceeds maximum allowed (0.5% of transaction_amount)
```

api2 sends a marketplace commission of **0.605%** (`MercadoPagoGateway::MAX_FEE_PERCENT` / the OAuth `application_fee_percent`), but this connector capped `application_fee` at **0.5%** of `transaction_amount` (`MAX_APPLICATION_FEE_RATIO = 0.005`). Since `0.605% > 0.5%`, the connector rejected the payment before it ever reached MercadoPago.

This started failing on the commission launch date (2026-07-01): before that, api2 sent no `application_fee`, so the validation never triggered.

## Fix

Raise `MAX_APPLICATION_FEE_RATIO` from `0.005` (0.5%) to `0.007` (0.7%). This covers the current 0.605% rate with headroom, and the error message is updated to match.

Both sides compare in the same unit (major units / `FloatMajorUnit`), so the ratio comparison is apples-to-apples.

## Note

The fee in api2 is computed on `budget_charges_total`, while MercadoPago validates against the actual `transaction_amount` charged. For partial charges the effective ratio can exceed the nominal rate — 0.7% gives more margin, but it's worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the MercadoPago connector’s application fee validation to allow a higher commission ceiling, raising `MAX_APPLICATION_FEE_RATIO` from `0.5%` to `0.7%` of `transaction_amount`. This resolves rejected MercadoPago v2 commission-enabled charges that were failing with `400 Bad Request` when api2 sent a `0.605%` marketplace commission.

The user-facing validation error was updated to match the new limit.

Architectural impact: minimal, limited to connector-side validation logic and error messaging.

Security considerations: no new security-sensitive behavior introduced; the change only broadens an allowed fee ratio.

Performance implications: none expected; the update is a constant change in validation thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->