### PR TITLE
feat(paypal): send PXSOL partner attribution id on all PayPal API calls

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/paypal.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal.rs
@@ -238,13 +238,17 @@ where
                 ),
                 (
                     auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID.to_string(),
-                    "HyperSwitchPPCP_SP".to_string().into(),
+                    auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE
+                        .to_string()
+                        .into(),
                 ),
             ])
         } else {
             headers.extend(vec![(
                 auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID.to_string(),
-                "HyperSwitchlegacy_Ecom".to_string().into(),
+                auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE
+                    .to_string()
+                    .into(),
             )])
         }
         Ok(headers)
@@ -417,6 +421,12 @@ impl ConnectorIntegration<AccessTokenAuth, AccessTokenRequestData, AccessToken> 
                 RefreshTokenType::get_content_type(self).to_string().into(),
             ),
             (headers::AUTHORIZATION.to_string(), auth_val.into_masked()),
+            (
+                auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID.to_string(),
+                auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE
+                    .to_string()
+                    .into(),
+            ),
         ])
     }
     fn get_request_body(
@@ -1933,6 +1943,12 @@ impl
                     .into(),
             ),
             (headers::AUTHORIZATION.to_string(), auth_val.into_masked()),
+            (
+                auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID.to_string(),
+                auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE
+                    .to_string()
+                    .into(),
+            ),
         ])
     }
 

--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -126,6 +126,8 @@ mod webhook_headers {
 }
 pub mod auth_headers {
     pub const PAYPAL_PARTNER_ATTRIBUTION_ID: &str = "PayPal-Partner-Attribution-Id";
+    /// PXSOL partner attribution id (BN code) sent on every PayPal API call.
+    pub const PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE: &str = "PXSOL_SP_CMReservas";
     pub const PREFER: &str = "Prefer";
     pub const PAYPAL_REQUEST_ID: &str = "PayPal-Request-Id";
     pub const PAYPAL_AUTH_ASSERTION: &str = "PayPal-Auth-Assertion";

--- a/crates/router/src/utils/connector_onboarding/paypal.rs
+++ b/crates/router/src/utils/connector_onboarding/paypal.rs
@@ -1,6 +1,7 @@
 use common_utils::request::{Method, Request, RequestBuilder, RequestContent};
 use error_stack::ResultExt;
 use http::header;
+use hyperswitch_connectors::connectors::paypal::transformers::auth_headers;
 
 use crate::{
     connector,
@@ -59,6 +60,10 @@ where
             header::CONTENT_TYPE.to_string().as_str(),
             "application/json",
         )
+        .header(
+            auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID,
+            auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE,
+        )
         .set_body(RequestContent::Json(Box::new(body)))
         .build())
 }
@@ -71,6 +76,10 @@ pub fn build_paypal_get_request(url: String, access_token: String) -> RouterResu
         .header(
             header::AUTHORIZATION.to_string().as_str(),
             format!("Bearer {access_token}").as_str(),
+        )
+        .header(
+            auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID,
+            auth_headers::PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE,
         )
         .build())
 }


### PR DESCRIPTION
## Qué

Envía el header `PayPal-Partner-Attribution-Id: PXSOL_SP_CMReservas` (BN code de PXSOL) en **todas** las llamadas API a PayPal.

Antes el conector ya mandaba el header pero con los valores hardcodeados de HyperSwitch (`HyperSwitchPPCP_SP` / `HyperSwitchlegacy_Ecom`), y varias llamadas (token OAuth, verificación de webhook, onboarding) no lo mandaban.

## Cómo

- Nueva constante única `PAYPAL_PARTNER_ATTRIBUTION_ID_VALUE = "PXSOL_SP_CMReservas"` en el módulo `auth_headers` (`paypal/transformers.rs`).
- `build_headers`: reemplaza **ambos** valores HyperSwitch (rama partner y legacy) por la constante → cubre orders/capture/void/refund/sync/payouts/authorize (incl. botón PayPal SDK)/session-tokens/setup-mandate/incremental-auth/preprocessing/complete-authorize.
- `RefreshToken::get_headers`: agrega el header a la llamada de token (`v1/oauth2/token`).
- `VerifyWebhookSource::get_headers`: agrega el header a la verificación de firma de webhook (`v1/notifications/verify-webhook-signature`).
- Onboarding (`utils/connector_onboarding/paypal.rs`): agrega el header a `build_paypal_post_request` y `build_paypal_get_request` (Partner Referrals API).

## Cobertura

Auditoría de las 18+ llamadas del conector: ningún `get_headers` queda sin el header, los 17 `build_request` toman headers de un `get_headers` cubierto, y no hay construcción de headers inline que lo saltee.

## Verificación

`cargo check -p hyperswitch_connectors -p router` → exit 0, `Finished` sin errores (solo warnings preexistentes ajenos al cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the PayPal integration to consistently send the `PayPal-Partner-Attribution-Id: PXSOL_SP_CMReservas` header across all relevant API flows.

- Replaced hardcoded, environment-specific HyperSwitch BN values in PayPal header construction with a single shared constant in `paypal/transformers.rs`.
- Propagated the partner attribution header through standard PayPal API requests, OAuth token refresh requests, webhook signature verification requests, and Partner Referrals onboarding requests.
- Updated router onboarding helpers to attach the new header on both POST and GET request paths.

Architecturally, this centralizes PayPal partner attribution handling, reducing duplication and making future changes to the BN code easier and less error-prone. Security impact is minimal; the change only adjusts outbound header metadata and does not alter authentication logic or sensitive data handling. Performance impact is negligible, with no meaningful runtime cost beyond adding a static header value to existing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->