### PR TITLE
fix(fiservemea): correctitud, 3DS de punta a punta y Card on File para homologar Fiserv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,22 @@ creds.json
 # Nix services data
 /data
 .pre-commit-config.yaml
+
+# Herramientas locales de homologación Fiserv
+/fiserv_homologacion_secrets/
+/fiserv_homologacion_logs/
+# Los dos scripts viejos tienen las credenciales CERT hardcodeadas.
+# fiserv_homologacion.py no: lee de fiserv_homologacion_secrets/creds.env.
+/fiserv_homologacion.sh
+/fiserv_3ds_local.py
+__pycache__/
+
+# Material local de la integración Fiserv / PXSOL: documentación del vendor, planillas de
+# homologación y scripts de prueba. Nada de esto va al repo.
+/PXSOL SAS/
+/homologacion_fiserv_checklist.csv
+/homologacion_fiserv_checklist.xlsx
+/homologacion_fiserv_mail.md
+/payway_apim_test.sh
+/wompi_tests/
+/.claude/

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -477,6 +477,10 @@ force_cookies = true                 # Whether to use only cookies for JWT extra
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 stripe = { long_lived_token = false, payment_method = "wallet", payment_method_type = { type = "disable_only", list = "google_pay" } }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 mollie = { long_lived_token = false, payment_method = "card" }
@@ -532,8 +536,8 @@ slack_invite_url = "https://www.example.com/"   # Slack invite url for hyperswit
 discord_invite_url = "https://www.example.com/" # Discord invite url for hyperswitch
 
 [zero_mandates.supported_payment_methods]
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,archipel"
 wallet.paypal = { connector_list = "adyen" }                                          # Mandate supported payment method type and connector for wallets
 pay_later.klarna = { connector_list = "adyen" }                                       # Mandate supported payment method type and connector for pay_later
 bank_debit.ach = { connector_list = "gocardless,adyen" }                              # Mandate supported payment method type and connector for bank_debit
@@ -548,8 +552,8 @@ wallet.google_pay = { connector_list = "bankofamerica,authorizedotnet,cybersourc
 bank_redirect.giropay = { connector_list = "globalpay" }
 
 [mandates.supported_payment_methods]
-card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv"
-card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv"
+card.credit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv"
+card.debit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv"
 wallet.paypal = { connector_list = "adyen,novalnet" }                                          # Mandate supported payment method type and connector for wallets
 pay_later.klarna = { connector_list = "adyen" }                                       # Mandate supported payment method type and connector for pay_later
 bank_debit.ach = { connector_list = "gocardless,adyen" }                              # Mandate supported payment method type and connector for bank_debit

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -213,8 +213,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless,adyen" }
 bank_debit.bacs = { connector_list = "gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
 pay_later.klarna.connector_list = "adyen"
 wallet.apple_pay.connector_list = "adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -237,8 +237,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen,stripe" }
 bank_debit.becs = { connector_list = "gocardless,stripe,adyen" }
 bank_debit.bacs = { connector_list = "stripe,gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
-card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
-card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.credit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.debit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
 pay_later.klarna.connector_list = "adyen,aci"
 wallet.apple_pay.connector_list = "stripe,adyen,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -852,6 +852,10 @@ credit = { country = "AR", currency = "ARS" }
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 braintree = { long_lived_token = false, payment_method = "card" }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 gocardless = { long_lived_token = true, payment_method = "bank_debit" }

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -223,8 +223,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless,adyen" }
 bank_debit.bacs = { connector_list = "gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
 pay_later.klarna.connector_list = "adyen"
 wallet.apple_pay.connector_list = "adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -247,8 +247,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen,stripe" }
 bank_debit.becs = { connector_list = "gocardless,stripe,adyen" }
 bank_debit.bacs = { connector_list = "stripe,gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
-card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
-card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.credit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.debit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
 pay_later.klarna.connector_list = "adyen,aci"
 wallet.apple_pay.connector_list = "stripe,adyen,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -871,6 +871,10 @@ credit = { country = "AR", currency = "ARS" }
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 braintree = { long_lived_token = false, payment_method = "card" }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 gocardless = { long_lived_token = true, payment_method = "bank_debit" }

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -220,8 +220,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless,adyen" }
 bank_debit.bacs = { connector_list = "gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
 pay_later.klarna.connector_list = "adyen"
 wallet.apple_pay.connector_list = "adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -244,8 +244,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen,stripe" }
 bank_debit.becs = { connector_list = "gocardless,stripe,adyen" }
 bank_debit.bacs = { connector_list = "stripe,gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
-card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
-card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.credit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.debit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
 pay_later.klarna.connector_list = "adyen,aci"
 wallet.apple_pay.connector_list = "stripe,adyen,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,worldpayvantiv"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -868,6 +868,10 @@ credit = { country = "AR", currency = "ARS" }
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 braintree = { long_lived_token = false, payment_method = "card" }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 gocardless = { long_lived_token = true, payment_method = "bank_debit" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -996,6 +996,10 @@ apple_pay = { country = "US,CA,IL,GB", currency = "ILS,USD,EUR" }
 credit = { country = "AR", currency = "ARS" }
 
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 stripe = { long_lived_token = false, payment_method = "wallet", payment_method_type = { type = "disable_only", list = "google_pay" } }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 stax = { long_lived_token = true, payment_method = "card,bank_debit" }
@@ -1068,8 +1072,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless,adyen" }
 bank_debit.bacs = { connector_list = "gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
 pay_later.klarna.connector_list = "adyen"
 wallet.apple_pay.connector_list = "adyen,cybersource,bankofamerica,novalnet,authorizedotnet"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -1093,8 +1097,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen,stripe" }
 bank_debit.becs = { connector_list = "gocardless,stripe,adyen" }
 bank_debit.bacs = { connector_list = "stripe,gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
-card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
-card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.credit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
+card.debit.connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload"
 pay_later.klarna.connector_list = "adyen,aci"
 wallet.apple_pay.connector_list = "stripe,adyen,cybersource,noon,bankofamerica,nuvei,nexinets,novalnet,authorizedotnet,wellsfargo,worldpayvantiv"
 wallet.samsung_pay.connector_list = "cybersource"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -398,6 +398,10 @@ workers = 1
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]
+# `flow = "mandates"` no es opcional: sin él el filtro del router acepta cualquier pago, y toda
+# venta con tarjeta se cursaría como PaymentTokenSaleTransaction en vez del PaymentCardSaleTransaction
+# con PAN que documenta el vendor, además de romper el 3DS, que la rama de token no soporta.
+fiservemea = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 stripe = { long_lived_token = false, payment_method = "wallet", payment_method_type = { type = "disable_only", list = "google_pay" } }
 checkout = { long_lived_token = false, payment_method = "wallet", apple_pay_pre_decrypt_flow = "network_tokenization" }
 mollie = { long_lived_token = false, payment_method = "card" }
@@ -993,8 +997,8 @@ bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless,adyen" }
 bank_debit.bacs = { connector_list = "gocardless" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
-card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
-card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.credit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
+card.debit.connector_list = "fiservemea,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel"
 pay_later.klarna.connector_list = "adyen"
 wallet.apple_pay.connector_list = "adyen,cybersource,bankofamerica,novalnet,authorizedotnet"
 wallet.samsung_pay.connector_list = "cybersource"
@@ -1018,8 +1022,8 @@ wallet.google_pay = { connector_list = "stripe,cybersource,adyen,bankofamerica,a
 wallet.apple_pay = { connector_list = "stripe,adyen,cybersource,noon,bankofamerica,authorizedotnet,novalnet,multisafepay,wellsfargo,nuvei" }
 wallet.samsung_pay = { connector_list = "cybersource" }
 wallet.paypal = { connector_list = "adyen,novalnet,authorizedotnet" }
-card.credit = { connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,elavon,xendit,novalnet,bamboraapac,archipel,wellsfargo,worldpayvantiv,payload" }
-card.debit = { connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,elavon,xendit,novalnet,bamboraapac,archipel,wellsfargo,worldpayvantiv,payload" }
+card.credit = { connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,elavon,xendit,novalnet,bamboraapac,archipel,wellsfargo,worldpayvantiv,payload" }
+card.debit = { connector_list = "fiservemea,aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,elavon,xendit,novalnet,bamboraapac,archipel,wellsfargo,worldpayvantiv,payload" }
 bank_debit.ach = { connector_list = "gocardless,adyen" }
 bank_debit.becs = { connector_list = "gocardless" }
 bank_debit.bacs = { connector_list = "adyen" }

--- a/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+mod cert_payloads;
+#[cfg(test)]
+mod cert_responses;
 pub mod transformers;
 
 use std::sync::LazyLock;
@@ -25,7 +29,7 @@ use hyperswitch_domain_models::{
     router_request_types::{
         AccessTokenRequestData, CompleteAuthorizeData, PaymentMethodTokenizationData,
         PaymentsAuthorizeData, PaymentsCancelData, PaymentsCaptureData, PaymentsSessionData,
-        PaymentsSyncData, RefundsData, SetupMandateRequestData,
+        PaymentsSyncData, RefundsData, ResponseId, SetupMandateRequestData,
     },
     router_response_types::{
         ConnectorInfo, PaymentMethodDetails, PaymentsResponseData, RefundsResponseData,
@@ -60,6 +64,15 @@ use crate::{
     utils::{self, RefundsRequestData as _},
 };
 
+/// `true` cuando este CompleteAuthorize es la notificación del 3DSMethod que el ACS publica en la
+/// `methodNotificationURL`, o sea la que ocurre dentro del iframe oculto.
+fn is_three_ds_method_notification(req: &PaymentsCompleteAuthorizeRouterData) -> bool {
+    req.request
+        .redirect_response
+        .as_ref()
+        .is_some_and(fiservemea::is_acs_method_notification)
+}
+
 fn determine_endpoint(
     connectors: &Connectors,
     test_mode: Option<bool>,
@@ -81,6 +94,54 @@ fn determine_endpoint(
     } else {
         Ok(connectors.fiservemea.base_url.to_string())
     }
+}
+
+/// Arma la URL del PSync eligiendo entre consultar por transacción o por orden.
+///
+/// El `ipgTransactionId` es la vía preferida, pero no siempre existe: hay rechazos que
+/// vuelven con HTTP 409 y `orderId` pero sin `ipgTransactionId` (verificado en cert con el
+/// Data Only rechazado: `TransactionErrorResponse` / `N:-50655:Unable to verify card
+/// enrollment`, sin id de transacción). Sin este fallback esos pagos quedan para siempre sin
+/// forma de consultarse. La guía (§7.3) habilita las dos consultas: se manda "el
+/// identificador de la transacción u orden" y se recibe "TransactionResponse u OrderResponse
+/// respectivamente"; verificado en vivo que `GET /orders/{orderId}?storeId=...` sobre una de
+/// esas órdenes rechazadas devuelve 200 con el `ipgTransactionId` que el rechazo nunca dio.
+///
+/// El `storeId` va como query param en las dos ramas (la firma HMAC del GET es sobre cuerpo
+/// vacío, así que el query no se firma). El identificador y el `storeId` se escapan con
+/// `url::Url`, que aplica a cada parte la regla que le corresponde: el segmento de path se
+/// percent-encodea y el query se form-encodea. La distinción importa — un espacio en un path
+/// es `%20` y no `+`; escaparlo con las reglas del query hace que el gateway responda
+/// `INVALID_INPUT` porque recibe un más literal.
+///
+/// Se extrae como función suelta para poder testear la elección sin construir un
+/// `PaymentsSyncRouterData` entero.
+fn build_sync_url(
+    base_url: &str,
+    connector_transaction_id: &ResponseId,
+    connector_request_reference_id: &str,
+    store_id: &str,
+) -> CustomResult<String, errors::ConnectorError> {
+    let (collection, id) = match connector_transaction_id {
+        // Un `ConnectorTransactionId` vacío se trata como ausente: `/payments/?storeId=` no es
+        // una consulta válida y el gateway respondería un error opaco.
+        ResponseId::ConnectorTransactionId(id) if !id.is_empty() => ("payments", id.as_str()),
+        _ if !connector_request_reference_id.is_empty() => {
+            ("orders", connector_request_reference_id)
+        }
+        // Sin ninguno de los dos identificadores no hay consulta posible.
+        _ => return Err(errors::ConnectorError::MissingConnectorTransactionID.into()),
+    };
+
+    let mut url = url::Url::parse(base_url)
+        .change_context(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
+    url.path_segments_mut()
+        .map_err(|_| errors::ConnectorError::FailedToObtainIntegrationUrl)?
+        .pop_if_empty()
+        .push(collection)
+        .push(id);
+    url.query_pairs_mut().append_pair("storeId", store_id);
+    Ok(url.into())
 }
 
 #[derive(Clone)]
@@ -122,6 +183,36 @@ impl Fiservemea {
         let signature_value = common_utils::consts::BASE64_ENGINE
             .encode(hmac::sign(&key, raw_signature.as_bytes()).as_ref());
         Ok(signature_value)
+    }
+}
+
+impl Fiservemea {
+    /// Headers firmados sobre un payload EXPLÍCITO, en vez de derivarlo de `get_http_method()`.
+    ///
+    /// Hace falta porque el CompleteAuthorize no tiene un método fijo: la continuación real va
+    /// por PATCH y firma el cuerpo, mientras que la notificación del 3DSMethod se degrada a una
+    /// consulta GET, que la API firma sobre cuerpo vacío.
+    fn signed_headers_for_payload<Flow, Req, Res>(
+        &self,
+        req: &RouterData<Flow, Req, Res>,
+        payload: &str,
+    ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000;
+        let auth = fiservemea::FiservemeaAuthType::try_from(&req.connector_auth_type)?;
+        let client_request_id = Uuid::new_v4().to_string();
+        let hmac = self
+            .generate_authorization_signature(auth.clone(), &client_request_id, payload, timestamp)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(vec![
+            (
+                headers::CONTENT_TYPE.to_string(),
+                self.common_get_content_type().to_string().into(),
+            ),
+            ("Client-Request-Id".to_string(), client_request_id.into()),
+            (headers::API_KEY.to_string(), auth.api_key.expose().into_masked()),
+            (headers::TIMESTAMP.to_string(), timestamp.to_string().into()),
+            (headers::MESSAGE_SIGNATURE.to_string(), hmac.into_masked()),
+        ])
     }
 }
 
@@ -388,6 +479,24 @@ impl ConnectorCommon for Fiservemea {
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
 
+        // Los rechazos del emisor llegan por acá (HTTP 422 / `EndpointDeclined`) con el bloque
+        // `processor` completo, así que es acá donde hay que publicar los códigos de red que
+        // gobiernan los reintentos. Se calcula antes del `match` porque el brazo consume
+        // `response.error`.
+        let network =
+            fiservemea::FiservemeaNetworkCodes::from_processor(response.processor.as_ref());
+        // Se toma antes del `match` por el mismo motivo que `network`: el brazo consume
+        // `response.error`. Sin esto el rechazo llega al comercio sin el id del gateway.
+        let connector_transaction_id = response.ipg_transaction_id.clone();
+        // El resultado de la autenticación 3DS se publica también acá: 11 de las 22 filas 3DS del
+        // checklist terminan en este camino (HTTP 409) y el `responseCode3dSecure` es el dato que
+        // Fiserv pide informar por caso.
+        let three_ds_metadata = response
+            .secure3d_response
+            .as_ref()
+            .and_then(fiservemea::FiservemeaSecure3dResponse::to_metadata)
+            .map(masking::Secret::new);
+
         match response.error {
             Some(error) => {
                 let details = error.details.map(|details| {
@@ -424,11 +533,11 @@ impl ConnectorCommon for Fiservemea {
                         None => error.message,
                     },
                     attempt_status: None,
-                    connector_transaction_id: None,
-                    network_advice_code: None,
-                    network_decline_code: None,
-                    network_error_message: None,
-                    connector_metadata: None,
+                    connector_transaction_id: connector_transaction_id.clone(),
+                    network_advice_code: network.advice_code,
+                    network_decline_code: network.decline_code,
+                    network_error_message: network.error_message,
+                    connector_metadata: three_ds_metadata.clone(),
                 })
             }
             None => Ok(ErrorResponse {
@@ -440,11 +549,11 @@ impl ConnectorCommon for Fiservemea {
                     .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
                 reason: response.response_type,
                 attempt_status: None,
-                connector_transaction_id: None,
-                network_advice_code: None,
-                network_decline_code: None,
-                network_error_message: None,
-                connector_metadata: None,
+                connector_transaction_id,
+                network_advice_code: network.advice_code,
+                network_decline_code: network.decline_code,
+                network_error_message: network.error_message,
+                connector_metadata: three_ds_metadata,
             }),
         }
     }
@@ -549,6 +658,11 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             http_code: res.status_code,
         })?;
         router_data.request.integrity_object = integrity_object;
+        // El `methodForm` del gateway es un iframe oculto con un form que apunta a ese mismo
+        // iframe: entregado crudo, el desafío se renderiza invisible y el tarjetahabiente nunca
+        // vuelve al comercio. Se envuelve en una página que sí navega la ventana principal.
+        // Va acá y no en la conversión de la respuesta porque la URL de retorno sale del request.
+        fiservemea::wrap_three_ds_method_redirection(&mut router_data);
         Ok(router_data)
     }
 
@@ -560,6 +674,10 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         self.build_error_response(res, event_builder)
     }
 }
+
+/// Código con el que el gateway rechaza una continuación 3DS que ya se cursó. Es la señal de
+/// que este CompleteAuthorize es el duplicado, no un fallo real del pago.
+const FISERVEMEA_ERROR_DUPLICATE_CONTINUATION: &str = "30056";
 
 impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResponseData>
     for Fiservemea
@@ -588,10 +706,21 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
             .connector_transaction_id
             .clone()
             .ok_or(errors::ConnectorError::MissingConnectorTransactionID)?;
-        Ok(format!(
-            "{}/payments/{connector_payment_id}",
-            determine_endpoint(connectors, req.test_mode)?
-        ))
+        let base_url = determine_endpoint(connectors, req.test_mode)?;
+        // La notificación que el ACS publica en la `methodNotificationURL` llega dentro del
+        // iframe oculto: su respuesta es invisible, así que no puede llevar la continuación. Se
+        // degrada a una consulta de estado, que es idempotente y deja que la continuación real
+        // la mande el retorno por la `termURL`, en la ventana principal.
+        if is_three_ds_method_notification(req) {
+            let auth = fiservemea::FiservemeaAuthType::try_from(&req.connector_auth_type)?;
+            return build_sync_url(
+                &base_url,
+                &ResponseId::ConnectorTransactionId(connector_payment_id),
+                &req.connector_request_reference_id,
+                auth.store_id.peek(),
+            );
+        }
+        Ok(format!("{base_url}/payments/{connector_payment_id}"))
     }
 
     fn get_request_body(
@@ -608,6 +737,22 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
         req: &PaymentsCompleteAuthorizeRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        // La notificación del 3DSMethod se resuelve con una consulta GET, firmada sobre cuerpo
+        // vacío y sin body. Así el PATCH de continuación sale una sola vez, desde el retorno por
+        // la termURL, y es su respuesta —la que trae el desafío— la que se renderiza en la
+        // ventana principal.
+        if is_three_ds_method_notification(req) {
+            return Ok(Some(
+                RequestBuilder::new()
+                    .method(Method::Get)
+                    .url(&types::PaymentsCompleteAuthorizeType::get_url(
+                        self, req, connectors,
+                    )?)
+                    .attach_default_headers()
+                    .headers(self.signed_headers_for_payload(req, "")?)
+                    .build(),
+            ));
+        }
         Ok(Some(
             RequestBuilder::new()
                 // The IPG continuation uses PATCH; `build_headers` signs the body for PATCH
@@ -660,7 +805,28 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
         res: Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res, event_builder)
+        let mut error = self.build_error_response(res, event_builder)?;
+        // Guarda de idempotencia del paso 3DS.
+        //
+        // El ACS puede publicar su notificación al `methodNotificationURL` mientras el navegador
+        // vuelve por el `termURL`, y las dos URLs son la misma (el `complete_authorize_url`), así
+        // que llegan dos CompleteAuthorize para la misma transacción. La guía avisa de esto y
+        // pide explícitamente no reenviar la continuación.
+        //
+        // La primera gana y la segunda recibe HTTP 409 `30056 "Referenced transaction does not
+        // exist"` (verificado contra cert: el primer PATCH devuelve APPROVED con
+        // `responseCode3dSecure: 1` y los siguientes, 409/30056). Sin esta guarda ese 409 se
+        // publicaría como fallo y pisaría un pago ya aprobado.
+        //
+        // Se deja el intento en `Pending` para que lo resuelva el PSync leyendo el estado real,
+        // en vez de afirmar un fallo que no ocurrió.
+        if error.code == FISERVEMEA_ERROR_DUPLICATE_CONTINUATION {
+            router_env::logger::info!(
+                "fiservemea: continuación 3DS duplicada (30056); se difiere al PSync"
+            );
+            error.attempt_status = Some(enums::AttemptStatus::Pending);
+        }
+        Ok(error)
     }
 }
 
@@ -686,23 +852,20 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Fis
         req: &PaymentsSyncRouterData,
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        let connector_payment_id = req
-            .request
-            .connector_transaction_id
-            .get_connector_transaction_id()
-            .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
         // The IPG sync (GET) requires the storeId as a query param (vendor doc, e.g.
         // `/payments/{id}?storeId=...`); the HMAC signature for GET is over an empty body, so
         // the query param is not part of the signed payload. `store_id` is a non-sensitive
-        // merchant identifier (also sent in request bodies); percent-encode it so the query
-        // string is always well-formed regardless of its contents.
+        // merchant identifier (also sent in request bodies).
         let auth = fiservemea::FiservemeaAuthType::try_from(&req.connector_auth_type)?;
-        let store_id: String =
-            url::form_urlencoded::byte_serialize(auth.store_id.peek().as_bytes()).collect();
-        Ok(format!(
-            "{}/payments/{connector_payment_id}?storeId={store_id}",
-            determine_endpoint(connectors, req.test_mode)?,
-        ))
+        // El `orderId` con el que se consulta es el mismo `connector_request_reference_id` que
+        // se mandó en `order.orderId` al autorizar (ver `FiservemeaOrder`), así que la orden
+        // existe aunque la venta haya fallado antes de devolver el `ipgTransactionId`.
+        build_sync_url(
+            &determine_endpoint(connectors, req.test_mode)?,
+            &req.request.connector_transaction_id,
+            &req.connector_request_reference_id,
+            auth.store_id.peek(),
+        )
     }
 
     fn build_request(
@@ -726,12 +889,16 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Fis
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsSyncRouterData, errors::ConnectorError> {
-        let response: fiservemea::FiservemeaPaymentsResponse = res
+        // La consulta devuelve `transactionResponse` u `orderResponse` según por cuál de los
+        // dos identificadores se haya preguntado (ver `build_sync_url`); se loguea la respuesta
+        // entera y recién después se reduce a la transacción que corresponde al intento.
+        let sync_response: fiservemea::FiservemeaSyncResponse = res
             .response
             .parse_struct("fiservemea PaymentsSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
+        event_builder.map(|i| i.set_response_body(&sync_response));
+        router_env::logger::info!(connector_response=?sync_response);
+        let response = sync_response.into_transaction()?;
 
         let integrity_object = response
             .settlement_amount()
@@ -1092,9 +1259,11 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Fiserveme
                 .url(&types::RefundSyncType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(types::RefundSyncType::get_headers(self, req, connectors)?)
-                .set_body(types::RefundSyncType::get_request_body(
-                    self, req, connectors,
-                )?)
+                // Sin `set_body`, igual que el PSync gemelo. El conector no define
+                // `get_request_body` para RSync, así que resolvía al default del trait: el
+                // string JSON `"{}"`, no un objeto. Y la firma HMAC se calcula sobre payload
+                // vacío porque `get_http_method()` es Get, o sea que ese body nunca estuvo
+                // firmado; hoy no rompe sólo porque el cliente HTTP descarta el body en GET.
                 .build(),
         ))
     }
@@ -1191,7 +1360,7 @@ static FISERVEMEA_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> =
             enums::PaymentMethod::Card,
             enums::PaymentMethodType::Credit,
             PaymentMethodDetails {
-                mandates: enums::FeatureStatus::NotSupported,
+                mandates: enums::FeatureStatus::Supported,
                 refunds: enums::FeatureStatus::Supported,
                 supported_capture_methods: supported_capture_methods.clone(),
                 specific_features: Some(
@@ -1210,7 +1379,7 @@ static FISERVEMEA_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> =
             enums::PaymentMethod::Card,
             enums::PaymentMethodType::Debit,
             PaymentMethodDetails {
-                mandates: enums::FeatureStatus::NotSupported,
+                mandates: enums::FeatureStatus::Supported,
                 refunds: enums::FeatureStatus::Supported,
                 supported_capture_methods: supported_capture_methods.clone(),
                 specific_features: Some(
@@ -1248,5 +1417,331 @@ impl ConnectorSpecifications for Fiservemea {
 
     fn get_supported_webhook_flows(&self) -> Option<&'static [enums::EventClass]> {
         Some(&FISERVEMEA_SUPPORTED_WEBHOOK_FLOWS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    const BASE: &str = "https://cert.api.firstdata.com/gateway/v2";
+
+    #[test]
+    fn sync_url_prefers_the_ipg_transaction_id() {
+        // Ruta normal, la que ya usaba el conector (verificada en cert:
+        // `GET /payments/84667286294?storeId=5926072901` devuelve 200).
+        let url = build_sync_url(
+            BASE,
+            &ResponseId::ConnectorTransactionId("84667286294".to_string()),
+            "PX-1786053423-06-inq",
+            "5926072901",
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "https://cert.api.firstdata.com/gateway/v2/payments/84667286294?storeId=5926072901"
+        );
+    }
+
+    #[test]
+    fn sync_url_falls_back_to_the_order_id() {
+        // Sin `ipgTransactionId` — el caso del Data Only rechazado, que vuelve 409 con
+        // `orderId` y sin id de transacción — se consulta la orden. Verificado en cert:
+        // `GET /orders/PX-1786053599-33-3ds-dataonly?storeId=5926072901` devuelve 200 y trae
+        // el `ipgTransactionId` que el rechazo nunca dio.
+        for connector_transaction_id in [
+            ResponseId::NoResponseId,
+            ResponseId::EncodedData("no-es-un-id".to_string()),
+            ResponseId::ConnectorTransactionId(String::new()),
+        ] {
+            let url = build_sync_url(
+                BASE,
+                &connector_transaction_id,
+                "PX-1786053599-33-3ds-dataonly",
+                "5926072901",
+            )
+            .unwrap();
+            assert_eq!(
+                url,
+                "https://cert.api.firstdata.com/gateway/v2/orders/PX-1786053599-33-3ds-dataonly?storeId=5926072901"
+            );
+        }
+    }
+
+    #[test]
+    fn sync_url_percent_encodes_merchant_controlled_values() {
+        // El `orderId` sale de la referencia del comercio: sin escapar, un `?`, un `#` o un
+        // espacio cambiarían la ruta o agregarían parámetros a la consulta.
+        //
+        // El espacio se escapa distinto en cada parte y no es un detalle cosmético: en el
+        // segmento de path va `%20`, y en el query va `+`. Mandar `+` en el path hace que el
+        // gateway reciba un más literal y responda `INVALID_INPUT`.
+        let url = build_sync_url(
+            BASE,
+            &ResponseId::NoResponseId,
+            "PX 2026/08#07?storeId=otra",
+            "59260 72901",
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "https://cert.api.firstdata.com/gateway/v2/orders/PX%202026%2F08%2307%3FstoreId=otra?storeId=59260+72901"
+        );
+        // El `=` queda sin escapar porque en un path es un carácter permitido y ahí es inerte:
+        // lo que importa es que el `?` viaje como `%3F` (no puede abrir un query) y el `/` como
+        // `%2F` (no puede agregar un segmento).
+    }
+
+    #[test]
+    fn sync_url_without_any_identifier_fails() {
+        // Sin transacción ni orden no hay nada que consultar: preferimos el error explícito
+        // antes que pegarle al gateway con `/orders/?storeId=...`.
+        assert!(build_sync_url(BASE, &ResponseId::NoResponseId, "", "5926072901").is_err());
+    }
+
+    #[test]
+    fn duplicate_three_ds_continuation_defers_to_psync() {
+        // Verificado contra cert: el primer PATCH de continuación devuelve APPROVED con
+        // `responseCode3dSecure: 1`, y los siguientes 409 con `30056`. Ese 409 NO puede
+        // publicarse como fallo, porque pisaría un pago ya aprobado.
+        assert_eq!(FISERVEMEA_ERROR_DUPLICATE_CONTINUATION, "30056");
+
+        let raw = serde_json::json!({
+            "type": "TransactionErrorResponse",
+            "responseType": "EndpointDeclined",
+            "transactionStatus": "VALIDATION_FAILED",
+            "error": { "code": "30056", "message": "Referenced transaction does not exist" }
+        });
+        let parsed: fiservemea::FiservemeaErrorResponse = serde_json::from_value(raw).unwrap();
+        assert_eq!(
+            parsed.error.and_then(|e| e.code).as_deref(),
+            Some(FISERVEMEA_ERROR_DUPLICATE_CONTINUATION)
+        );
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Rutas contrastadas contra las que el gateway de certificación aceptó con HTTP 200
+    // (fiserv_homologacion_logs/20260806-215656/evidencia.jsonl):
+    //   línea  9 → POST /payments/84667286296   (VOID)
+    //   línea 11 → POST /payments/84667286298   (RETURN total)
+    //   línea 13 → POST /payments/84667286310   (RETURN parcial)
+    // Las de INQUIRY (líneas 6 y 7) ya quedan fijadas por los tests de `build_sync_url`.
+    // ---------------------------------------------------------------------------------
+
+    fn cert_connectors() -> Connectors {
+        let mut connectors = Connectors::default();
+        connectors.fiservemea.base_url = format!("{BASE}/");
+        connectors.fiservemea.secondary_base_url = Some(BASE.to_string());
+        connectors
+    }
+
+    fn url_router_data<Flow, Req, Res>(request: Req) -> RouterData<Flow, Req, Res> {
+        RouterData {
+            flow: std::marker::PhantomData,
+            merchant_id: common_utils::id_type::MerchantId::default(),
+            customer_id: None,
+            connector_customer: None,
+            connector: "fiservemea".to_string(),
+            payment_id: "pay_1".to_string(),
+            attempt_id: "att_1".to_string(),
+            tenant_id: common_utils::id_type::TenantId::try_from_string("public".to_string())
+                .unwrap(),
+            status: enums::AttemptStatus::Pending,
+            payment_method: enums::PaymentMethod::Card,
+            connector_auth_type:
+                hyperswitch_domain_models::router_data::ConnectorAuthType::SignatureKey {
+                api_key: masking::Secret::new("apikey".to_string()),
+                key1: masking::Secret::new("5926072901".to_string()),
+                api_secret: masking::Secret::new("apisecret".to_string()),
+            },
+            description: None,
+            address: hyperswitch_domain_models::payment_address::PaymentAddress::default(),
+            auth_type: enums::AuthenticationType::NoThreeDs,
+            connector_meta_data: None,
+            connector_wallets_details: None,
+            amount_captured: None,
+            access_token: None,
+            session_token: None,
+            reference_id: None,
+            payment_method_token: None,
+            recurring_mandate_payment_data: None,
+            preprocessing_id: None,
+            payment_method_balance: None,
+            connector_api_version: None,
+            request,
+            response: Err(ErrorResponse::default()),
+            connector_request_reference_id: "PX-1786053424-07-void".to_string(),
+            #[cfg(feature = "payouts")]
+            payout_method_data: None,
+            #[cfg(feature = "payouts")]
+            quote_id: None,
+            // Ambiente de certificación: el conector exige `secondary_base_url` para poder
+            // enrutar a cert (falla cerrado si no está configurada).
+            test_mode: Some(true),
+            connector_http_status_code: None,
+            external_latency: None,
+            apple_pay_flow: None,
+            frm_metadata: None,
+            dispute_id: None,
+            refund_id: None,
+            connector_response: None,
+            payment_method_status: None,
+            minor_amount_captured: None,
+            minor_amount_capturable: None,
+            integrity_check: Ok(()),
+            additional_merchant_data: None,
+            header_payload: None,
+            connector_mandate_request_reference_id: None,
+            l2_l3_data: None,
+            authentication_id: None,
+            psd2_sca_exemption_type: None,
+            raw_connector_response: None,
+            is_payment_id_from_merchant: None,
+        }
+    }
+
+    #[test]
+    fn void_url_and_method_match_the_accepted_cert_call() {
+        let req: PaymentsCancelRouterData = url_router_data(PaymentsCancelData {
+            connector_transaction_id: "84667286296".to_string(),
+            capture_method: Some(enums::CaptureMethod::Automatic),
+            ..Default::default()
+        });
+        let connector = Fiservemea::new();
+        let url =
+            ConnectorIntegration::<Void, PaymentsCancelData, PaymentsResponseData>::get_url(
+                connector,
+                &req,
+                &cert_connectors(),
+            )
+            .unwrap();
+        assert_eq!(
+            url,
+            "https://cert.api.firstdata.com/gateway/v2/payments/84667286296"
+        );
+        // El VOID del checklist salió por POST, no por PATCH ni DELETE.
+        assert_eq!(
+            ConnectorIntegration::<Void, PaymentsCancelData, PaymentsResponseData>::get_http_method(
+                connector
+            ),
+            Method::Post
+        );
+    }
+
+    fn cert_refunds_data(connector_transaction_id: &str, refund_amount: i64) -> RefundsData {
+        RefundsData {
+            refund_id: "ref_1".to_string(),
+            connector_transaction_id: connector_transaction_id.to_string(),
+            connector_refund_id: None,
+            currency: enums::Currency::ARS,
+            payment_amount: 100_000,
+            reason: None,
+            webhook_url: None,
+            refund_amount,
+            connector_metadata: None,
+            refund_connector_metadata: None,
+            browser_info: None,
+            split_refunds: None,
+            minor_payment_amount: common_utils::types::MinorUnit::new(100_000),
+            minor_refund_amount: common_utils::types::MinorUnit::new(refund_amount),
+            integrity_object: None,
+            refund_status: enums::RefundStatus::Pending,
+            merchant_account_id: None,
+            merchant_config_currency: None,
+            capture_method: Some(enums::CaptureMethod::Automatic),
+            additional_payment_method_data: None,
+        }
+    }
+
+    #[test]
+    fn refund_url_and_method_match_the_accepted_cert_calls() {
+        let connector = Fiservemea::new();
+        for (transaction_id, refund_amount) in [("84667286298", 100_000), ("84667286310", 50_000)] {
+            let req: RefundsRouterData<Execute> =
+                url_router_data(cert_refunds_data(transaction_id, refund_amount));
+            let url = ConnectorIntegration::<Execute, RefundsData, RefundsResponseData>::get_url(
+                connector,
+                &req,
+                &cert_connectors(),
+            )
+            .unwrap();
+            assert_eq!(
+                url,
+                format!("https://cert.api.firstdata.com/gateway/v2/payments/{transaction_id}")
+            );
+        }
+        assert_eq!(
+            ConnectorIntegration::<Execute, RefundsData, RefundsResponseData>::get_http_method(
+                connector
+            ),
+            Method::Post
+        );
+    }
+
+    /// El PSync del reembolso (RSync) consulta la MISMA colección `/payments` con el
+    /// `storeId` como query param, igual que el INQUIRY que el gateway aceptó (línea 6).
+    #[test]
+    fn refund_sync_url_carries_the_store_id_as_query_param() {
+        let connector = Fiservemea::new();
+        let mut data = cert_refunds_data("84667286298", 100_000);
+        data.connector_refund_id = Some("84667286299".to_string());
+        let req: RefundSyncRouterData = url_router_data(data);
+        let url = ConnectorIntegration::<RSync, RefundsData, RefundsResponseData>::get_url(
+            connector,
+            &req,
+            &cert_connectors(),
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "https://cert.api.firstdata.com/gateway/v2/payments/84667286299?storeId=5926072901"
+        );
+    }
+
+    /// La captura NO forma parte de los 31 casos de la homologación (todos son ventas).
+    /// Este test sólo fija la ruta que el conector emite; no está verificada contra el gateway.
+    #[test]
+    fn capture_url_targets_the_original_transaction_not_verified_against_cert() {
+        let connector = Fiservemea::new();
+        let req: PaymentsCaptureRouterData = url_router_data(PaymentsCaptureData {
+            connector_transaction_id: "84667286296".to_string(),
+            currency: enums::Currency::ARS,
+            amount_to_capture: 100_000,
+            payment_amount: 100_000,
+            minor_payment_amount: common_utils::types::MinorUnit::new(100_000),
+            minor_amount_to_capture: common_utils::types::MinorUnit::new(100_000),
+            ..Default::default()
+        });
+        let url =
+            ConnectorIntegration::<Capture, PaymentsCaptureData, PaymentsResponseData>::get_url(
+                connector,
+                &req,
+                &cert_connectors(),
+            )
+            .unwrap();
+        assert_eq!(
+            url,
+            "https://cert.api.firstdata.com/gateway/v2/payments/84667286296"
+        );
+    }
+
+    /// El endpoint de cert sólo se usa si está configurado explícitamente: con `test_mode`
+    /// prendido y sin `secondary_base_url` el conector falla en vez de irse a producción.
+    #[test]
+    fn test_mode_without_secondary_base_url_fails_closed() {
+        let mut connectors = cert_connectors();
+        connectors.fiservemea.secondary_base_url = None;
+        let req: PaymentsCancelRouterData = url_router_data(PaymentsCancelData {
+            connector_transaction_id: "84667286296".to_string(),
+            ..Default::default()
+        });
+        assert!(ConnectorIntegration::<Void, PaymentsCancelData, PaymentsResponseData>::get_url(
+            Fiservemea::new(),
+            &req,
+            &connectors
+        )
+        .is_err());
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/fiservemea/cert_payloads.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea/cert_payloads.rs
@@ -1,0 +1,908 @@
+//! SCRATCH / no productivo. Dumpea a disco los payloads que el conector genera para los casos
+//! del checklist de homologación, para poder mandarlos al gateway de certificación tal cual
+//! salen del conector. Se corre con:
+//!
+//!   cargo test -p hyperswitch_connectors --lib --features v1 \
+//!       fiservemea::cert_payloads -- --nocapture
+//!
+//! Directorio de salida: $FISERVEMEA_DUMP_DIR (default /tmp/fiservemea_payloads).
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::too_many_arguments,
+    clippy::indexing_slicing
+)]
+
+use std::{collections::HashMap, marker::PhantomData, str::FromStr};
+
+use common_enums::enums;
+use common_utils::{request::RequestContent, types::MinorUnit};
+use hyperswitch_domain_models::{
+    payment_address::PaymentAddress,
+    payment_method_data::{Card, PaymentMethodData},
+    router_data::{ConnectorAuthType, ErrorResponse, PaymentMethodToken, RouterData},
+    router_flow_types::{
+        payments::{Authorize, PaymentMethodToken as PmTokenFlow, SetupMandate},
+        refunds::Execute,
+        CompleteAuthorize, Void,
+    },
+    router_request_types::{
+        CompleteAuthorizeData, CompleteAuthorizeRedirectResponse, PaymentMethodTokenizationData,
+        PaymentsAuthorizeData, PaymentsCancelData, RefundsData, SetupMandateRequestData,
+    },
+    router_response_types::PaymentsResponseData,
+};
+use masking::{ExposeInterface, Secret};
+use serde_json::json;
+
+use super::transformers as fiservemea;
+use crate::connectors::Fiservemea;
+
+// ---------------------------------------------------------------- infra de dump
+
+fn dump_dir() -> std::path::PathBuf {
+    let dir = std::env::var("FISERVEMEA_DUMP_DIR")
+        .unwrap_or_else(|_| "/tmp/fiservemea_payloads".to_string());
+    std::fs::create_dir_all(&dir).unwrap();
+    std::path::PathBuf::from(dir)
+}
+
+/// Serializa el body tal como lo haría el conector (`RequestContent::Json` ->
+/// `get_inner_value`, que es exactamente lo que sale por el cable) y lo escribe.
+fn dump(case: &str, method: &str, path: &str, body: RequestContent) {
+    assert!(
+        matches!(body, RequestContent::Json(_)),
+        "fiservemea no debería producir otro RequestContent"
+    );
+    let raw = body.get_inner_value().expose();
+    let json_body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    write_case(case, method, path, Some(json_body));
+}
+
+fn write_case(case: &str, method: &str, path: &str, body: Option<serde_json::Value>) {
+    let dir = dump_dir();
+    let entry = json!({
+        "case": case,
+        "method": method,
+        "path": path,
+        "body": body,
+    });
+    std::fs::write(
+        dir.join(format!("{case}.json")),
+        serde_json::to_string_pretty(&entry).unwrap(),
+    )
+    .unwrap();
+    println!("[dump] {case} -> {method} {path}");
+}
+
+// ---------------------------------------------------------------- constructores
+
+const STORE_AR: &str = "5926072901";
+const STORE_TOKEN_GW: &str = "5926072902";
+
+fn auth(store: &str) -> ConnectorAuthType {
+    ConnectorAuthType::SignatureKey {
+        api_key: Secret::new(std::env::var("AR_KEY").unwrap_or_else(|_| "k".into())),
+        key1: Secret::new(store.to_string()),
+        api_secret: Secret::new(std::env::var("AR_SECRET").unwrap_or_else(|_| "s".into())),
+    }
+}
+
+fn card(number: &str) -> Card {
+    Card {
+        card_number: cards::CardNumber::from_str(number).unwrap(),
+        card_exp_month: Secret::new("12".to_string()),
+        card_exp_year: Secret::new("2029".to_string()),
+        card_cvc: Secret::new("123".to_string()),
+        card_issuer: None,
+        card_network: None,
+        card_type: None,
+        card_issuing_country: None,
+        bank_code: None,
+        nick_name: None,
+        card_holder_name: Some(Secret::new("PXSOL TEST".to_string())),
+        co_badged_card_data: None,
+    }
+}
+
+fn authorize_data(
+    number: &str,
+    currency: enums::Currency,
+    amount_minor: i64,
+    metadata: Option<serde_json::Value>,
+    three_ds: bool,
+) -> PaymentsAuthorizeData {
+    PaymentsAuthorizeData {
+        payment_method_data: PaymentMethodData::Card(card(number)),
+        amount: amount_minor,
+        minor_amount: MinorUnit::new(amount_minor),
+        order_tax_amount: None,
+        email: None,
+        customer_name: None,
+        currency,
+        confirm: true,
+        statement_descriptor_suffix: None,
+        statement_descriptor: None,
+        capture_method: Some(enums::CaptureMethod::Automatic),
+        router_return_url: None,
+        webhook_url: None,
+        complete_authorize_url: three_ds
+            .then(|| "https://www.pxsol.com/3ds/return".to_string()),
+        setup_future_usage: None,
+        mandate_id: None,
+        off_session: None,
+        customer_acceptance: None,
+        setup_mandate_details: None,
+        browser_info: None,
+        order_details: None,
+        order_category: None,
+        session_token: None,
+        enrolled_for_3ds: three_ds,
+        related_transaction_id: None,
+        payment_experience: None,
+        payment_method_type: None,
+        surcharge_details: None,
+        customer_id: None,
+        request_incremental_authorization: false,
+        metadata,
+        authentication_data: None,
+        request_extended_authorization: None,
+        split_payments: None,
+        merchant_order_reference_id: None,
+        integrity_object: None,
+        shipping_cost: None,
+        additional_payment_method_data: None,
+        merchant_account_id: None,
+        merchant_config_currency: None,
+        connector_testing_data: None,
+        order_id: None,
+        locale: None,
+        payment_channel: None,
+        enable_partial_authorization: None,
+        enable_overcapture: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn router_data<Flow, Req, Res>(
+    request: Req,
+    store: &str,
+    order_id: &str,
+    three_ds: bool,
+    pm_token: Option<String>,
+) -> RouterData<Flow, Req, Res> {
+    RouterData {
+        flow: PhantomData,
+        merchant_id: common_utils::id_type::MerchantId::try_from(std::borrow::Cow::from(
+            "fiservemea",
+        ))
+        .unwrap(),
+        customer_id: None,
+        connector_customer: None,
+        connector: "fiservemea".to_string(),
+        payment_id: order_id.to_string(),
+        attempt_id: order_id.to_string(),
+        tenant_id: common_utils::id_type::TenantId::try_from_string("public".to_string()).unwrap(),
+        status: enums::AttemptStatus::default(),
+        payment_method: enums::PaymentMethod::Card,
+        connector_auth_type: auth(store),
+        description: None,
+        address: PaymentAddress::default(),
+        auth_type: if three_ds {
+            enums::AuthenticationType::ThreeDs
+        } else {
+            enums::AuthenticationType::NoThreeDs
+        },
+        connector_meta_data: None,
+        connector_wallets_details: None,
+        amount_captured: None,
+        access_token: None,
+        session_token: None,
+        reference_id: None,
+        payment_method_token: pm_token.map(|t| PaymentMethodToken::Token(Secret::new(t))),
+        recurring_mandate_payment_data: None,
+        preprocessing_id: None,
+        payment_method_balance: None,
+        connector_api_version: None,
+        request,
+        response: Err(ErrorResponse::default()),
+        connector_request_reference_id: order_id.to_string(),
+        #[cfg(feature = "payouts")]
+        payout_method_data: None,
+        #[cfg(feature = "payouts")]
+        quote_id: None,
+        test_mode: Some(true),
+        connector_http_status_code: None,
+        external_latency: None,
+        apple_pay_flow: None,
+        frm_metadata: None,
+        dispute_id: None,
+        refund_id: None,
+        connector_response: None,
+        payment_method_status: None,
+        minor_amount_captured: None,
+        minor_amount_capturable: None,
+        integrity_check: Ok(()),
+        additional_merchant_data: None,
+        header_payload: None,
+        connector_mandate_request_reference_id: None,
+        l2_l3_data: None,
+        authentication_id: None,
+        psd2_sca_exemption_type: None,
+        raw_connector_response: None,
+        is_payment_id_from_merchant: None,
+    }
+}
+
+/// `order_id` estable-por-corrida, con el mismo formato que usa el harness.
+fn order_id(tag: &str) -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    format!("HS-{ts}-{tag}").chars().take(40).collect()
+}
+
+/// Construye y dumpea un Authorize pasando por el mismo camino que el conector real:
+/// `convert_amount` -> `FiservemeaRouterData` -> `FiservemeaPaymentsRequest`.
+fn dump_authorize(
+    case: &str,
+    store: &str,
+    number: &str,
+    currency: enums::Currency,
+    amount_minor: i64,
+    metadata: Option<serde_json::Value>,
+    three_ds: bool,
+    pm_token: Option<String>,
+) {
+    let oid = order_id(case);
+    let request = authorize_data(number, currency, amount_minor, metadata, three_ds);
+    let rd: RouterData<Authorize, _, _> = router_data(request, store, &oid, three_ds, pm_token);
+    let amount = crate::utils::convert_amount(
+        Fiservemea::new().amount_converter,
+        rd.request.minor_amount,
+        rd.request.currency,
+    )
+    .unwrap();
+    let crd = fiservemea::FiservemeaRouterData::from((amount, &rd));
+    let req = fiservemea::FiservemeaPaymentsRequest::try_from(&crd).unwrap();
+    dump(case, "POST", "/payments", RequestContent::Json(Box::new(req)));
+}
+
+// ---------------------------------------------------------------- fase 1
+
+#[test]
+fn dump_phase1_payloads() {
+    // 1. sale 1 pago (ARS)
+    dump_authorize(
+        "sale-1pago",
+        STORE_AR,
+        "5165850000000008",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        false,
+        None,
+    );
+
+    // 2. sale USD
+    dump_authorize(
+        "sale-usd",
+        STORE_AR,
+        "5165850000000008",
+        enums::Currency::USD,
+        100_000,
+        None,
+        false,
+        None,
+    );
+
+    // 3. sale en cuotas (6)
+    dump_authorize(
+        "sale-cuotas6",
+        STORE_AR,
+        "5165850000000008",
+        enums::Currency::ARS,
+        100_000,
+        Some(json!({ "installments": 6 })),
+        false,
+        None,
+    );
+
+    // 4. dynamic merchant name
+    dump_authorize(
+        "sale-dmn",
+        STORE_AR,
+        "5165850000000008",
+        enums::Currency::ARS,
+        100_000,
+        Some(json!({ "dynamic_merchant_name": "PXSOL*Reservas" })),
+        false,
+        None,
+    );
+
+    // 5. zero auth (SetupMandate)
+    {
+        let oid = order_id("zeroauth");
+        let request = SetupMandateRequestData {
+            currency: enums::Currency::ARS,
+            payment_method_data: PaymentMethodData::Card(card("5165850000000008")),
+            amount: Some(0),
+            confirm: true,
+            statement_descriptor_suffix: None,
+            customer_acceptance: None,
+            mandate_id: None,
+            setup_future_usage: None,
+            off_session: None,
+            setup_mandate_details: None,
+            router_return_url: None,
+            webhook_url: None,
+            browser_info: None,
+            email: None,
+            customer_name: None,
+            return_url: None,
+            payment_method_type: None,
+            request_incremental_authorization: false,
+            metadata: None,
+            complete_authorize_url: None,
+            capture_method: None,
+            enrolled_for_3ds: false,
+            related_transaction_id: None,
+            minor_amount: Some(MinorUnit::zero()),
+            shipping_cost: None,
+            connector_testing_data: None,
+            customer_id: None,
+            enable_partial_authorization: None,
+            payment_channel: None,
+        };
+        let rd: RouterData<SetupMandate, _, _> = router_data(request, STORE_AR, &oid, false, None);
+        let req = fiservemea::FiservemeaPaymentsRequest::try_from(&rd).unwrap();
+        dump(
+            "zeroauth",
+            "POST",
+            "/payments",
+            RequestContent::Json(Box::new(req)),
+        );
+    }
+
+    // 6. create token GW (tienda de tokens)
+    {
+        let oid = order_id("tokengw-create");
+        let request = PaymentMethodTokenizationData {
+            payment_method_data: PaymentMethodData::Card(card("5165850000000008")),
+            browser_info: None,
+            currency: enums::Currency::ARS,
+            amount: Some(100_000),
+            split_payments: None,
+            customer_acceptance: None,
+            setup_future_usage: None,
+            setup_mandate_details: None,
+            mandate_id: None,
+        };
+        let rd: RouterData<PmTokenFlow, _, _> =
+            router_data(request, STORE_TOKEN_GW, &oid, false, None);
+        let req = fiservemea::FiservemeaCreateTokenRequest::try_from(&rd).unwrap();
+        dump(
+            "tokengw-create",
+            "POST",
+            "/payment-tokens",
+            RequestContent::Json(Box::new(req)),
+        );
+    }
+
+    // 7. 3DS frictionless (Authenticated) — init
+    dump_authorize(
+        "3ds-fric-y",
+        STORE_AR,
+        "4147463011110083",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        true,
+        None,
+    );
+
+    // 8. 3DSMethod (Authenticated) — init
+    dump_authorize(
+        "3ds-mth-y",
+        STORE_AR,
+        "4099000000001978",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        true,
+        None,
+    );
+
+    // 8b. 3DSMethod (Authenticated) — segunda transacción, para probar la variante en la que el
+    // retorno SÍ trae `threeDSMethodData` y el conector emite `RECEIVED`.
+    dump_authorize(
+        "3ds-mth-y-received",
+        STORE_AR,
+        "4099000000001978",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        true,
+        None,
+    );
+
+    // 9. Challenge configurable — init
+    dump_authorize(
+        "3ds-cha-1",
+        STORE_AR,
+        "4147463011110059",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        true,
+        None,
+    );
+
+    // 10. Challenge+Method configurable — init
+    dump_authorize(
+        "3ds-chm-1",
+        STORE_AR,
+        "4265880000000064",
+        enums::Currency::ARS,
+        100_000,
+        None,
+        true,
+        None,
+    );
+
+    // 11. Data Only (Mastercard, messageCategory 80) — init
+    dump_authorize(
+        "3ds-dataonly",
+        STORE_AR,
+        "5239290700000028",
+        enums::Currency::ARS,
+        100_000,
+        Some(json!({ "three_ds_data_only": true })),
+        true,
+        None,
+    );
+}
+
+/// Segunda fase: paga con el token GW recién creado por la fase 1. El valor lo deja el script
+/// de Python en `token_gw.txt`.
+#[test]
+fn dump_phase2_token_sale() {
+    let path = dump_dir().join("token_gw.txt");
+    let Ok(token) = std::fs::read_to_string(&path) else {
+        println!("[skip] no hay token_gw.txt todavía");
+        return;
+    };
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        println!("[skip] token_gw.txt vacío");
+        return;
+    }
+    dump_authorize(
+        "tokengw-sale-cuotas6",
+        STORE_TOKEN_GW,
+        "5165850000000008",
+        enums::Currency::ARS,
+        100_000,
+        Some(json!({ "installments": 6 })),
+        false,
+        Some(token),
+    );
+}
+
+/// Plantillas de continuación 3DS, generadas por el conector a partir de un `redirect_response`
+/// sintético (no leído de disco), para poder mandarlas SIN el hueco de varios minutos que mete
+/// tener que volver a correr `cargo test` entre el init y el PATCH. El cuerpo del PATCH sólo
+/// depende de (storeId, estado): no lleva el `ipgTransactionId`, que va en la URL.
+#[test]
+fn dump_phase5_continuation_templates() {
+    let cases: [(&str, Option<&str>, Option<serde_json::Value>); 3] = [
+        // Retorno por la termURL sin `threeDSMethodData`: lo que pasa de verdad en el flujo del
+        // conector, porque la notificación del ACS entra por la methodNotificationURL.
+        ("tmpl-cont-expected", Some("fiservemea3ds=term"), None),
+        // Retorno por la termURL que además trae la notificación: la única forma de que el
+        // conector emita RECEIVED.
+        (
+            "tmpl-cont-received",
+            Some("fiservemea3ds=term"),
+            Some(json!({ "threeDSMethodData": "PLACEHOLDER" })),
+        ),
+        // Retorno del desafío con el cRes.
+        (
+            "tmpl-cont-cres",
+            Some("fiservemea3ds=term"),
+            Some(json!({ "cres": "CRES_PLACEHOLDER" })),
+        ),
+    ];
+    for (case, params, payload) in cases {
+        let redirect_response = CompleteAuthorizeRedirectResponse {
+            params: params.map(|p| Secret::new(p.to_string())),
+            payload: payload.map(Secret::new),
+        };
+        let request = CompleteAuthorizeData {
+            payment_method_data: None,
+            amount: 100_000,
+            email: None,
+            currency: enums::Currency::ARS,
+            confirm: true,
+            statement_descriptor_suffix: None,
+            capture_method: Some(enums::CaptureMethod::Automatic),
+            setup_future_usage: None,
+            mandate_id: None,
+            off_session: None,
+            setup_mandate_details: None,
+            redirect_response: Some(redirect_response),
+            browser_info: None,
+            connector_transaction_id: Some("TEMPLATE".to_string()),
+            connector_meta: None,
+            complete_authorize_url: Some("https://www.pxsol.com/3ds/return".to_string()),
+            metadata: None,
+            customer_acceptance: None,
+            minor_amount: MinorUnit::new(100_000),
+            merchant_account_id: None,
+            merchant_config_currency: None,
+            threeds_method_comp_ind: None,
+        };
+        let rd: RouterData<CompleteAuthorize, _, _> =
+            router_data(request, STORE_AR, case, true, None);
+        let req = fiservemea::FiservemeaCompleteAuthorizeRequest::try_from(&rd).unwrap();
+        dump(case, "PATCH", "/payments/{ipg}", RequestContent::Json(Box::new(req)));
+    }
+}
+
+/// Inits 3DS extra, con `orderId` propio, para que el driver de Python pueda correr cada flujo
+/// de punta a punta en segundos usando las plantillas de arriba.
+#[test]
+fn dump_phase5_fast_inits() {
+    for (case, number) in [
+        ("fast-mth-expected", "4099000000001978"),
+        ("fast-mth-received", "4099000000001978"),
+        ("fast-chm-1", "4265880000000064"),
+        ("fast-cha-1", "4147463011110059"),
+    ] {
+        dump_authorize(
+            case,
+            STORE_AR,
+            number,
+            enums::Currency::ARS,
+            100_000,
+            None,
+            true,
+            None,
+        );
+    }
+}
+
+/// Tercera fase: continuaciones 3DS. El script de Python deja en `acs/<case>.json` lo que el ACS
+/// devolvió de verdad (`{"ipg": ..., "params": "<query string>"}` o `{"payload": {...}}`), y acá se
+/// construye el `CompleteAuthorizeRouterData` con eso, para que el body del PATCH lo genere el
+/// conector.
+#[test]
+fn dump_phase3_continuations() {
+    let acs_dir = dump_dir().join("acs");
+    let Ok(entries) = std::fs::read_dir(&acs_dir) else {
+        println!("[skip] no hay acs/ todavía");
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let case = path.file_stem().unwrap().to_str().unwrap().to_string();
+        let ipg = raw["ipg"].as_str().unwrap().to_string();
+        let redirect_response = CompleteAuthorizeRedirectResponse {
+            params: raw
+                .get("params")
+                .and_then(|v| v.as_str())
+                .map(|s| Secret::new(s.to_string())),
+            payload: raw
+                .get("payload")
+                .filter(|v| !v.is_null())
+                .map(|v| Secret::new(v.clone())),
+        };
+        let store = raw
+            .get("store")
+            .and_then(|v| v.as_str())
+            .unwrap_or(STORE_AR)
+            .to_string();
+        let request = CompleteAuthorizeData {
+            payment_method_data: None,
+            amount: 100_000,
+            email: None,
+            currency: enums::Currency::ARS,
+            confirm: true,
+            statement_descriptor_suffix: None,
+            capture_method: Some(enums::CaptureMethod::Automatic),
+            setup_future_usage: None,
+            mandate_id: None,
+            off_session: None,
+            setup_mandate_details: None,
+            redirect_response: Some(redirect_response),
+            browser_info: None,
+            connector_transaction_id: Some(ipg.clone()),
+            connector_meta: None,
+            complete_authorize_url: Some("https://www.pxsol.com/3ds/return".to_string()),
+            metadata: None,
+            customer_acceptance: None,
+            minor_amount: MinorUnit::new(100_000),
+            merchant_account_id: None,
+            merchant_config_currency: None,
+            threeds_method_comp_ind: None,
+        };
+        let rd: RouterData<CompleteAuthorize, _, _> = router_data(
+            request,
+            &store,
+            raw.get("order_id").and_then(|v| v.as_str()).unwrap_or(&case),
+            true,
+            None,
+        );
+        // Espeja `build_request` del conector: la notificación del 3DSMethod se degrada a GET
+        // sin cuerpo; la continuación real es un PATCH con cuerpo.
+        if fiservemea::is_acs_method_notification(rd.request.redirect_response.as_ref().unwrap()) {
+            write_case(
+                &format!("cont-{case}"),
+                "GET",
+                &format!("/payments/{ipg}?storeId={store}"),
+                None,
+            );
+        } else {
+            let req = fiservemea::FiservemeaCompleteAuthorizeRequest::try_from(&rd).unwrap();
+            dump(
+                &format!("cont-{case}"),
+                "PATCH",
+                &format!("/payments/{ipg}"),
+                RequestContent::Json(Box::new(req)),
+            );
+        }
+    }
+}
+
+/// Cierra el círculo: cada respuesta REAL que el gateway devolvió a los payloads del conector
+/// tiene que poder deserializarse con los tipos del conector. Sin esto, un payload aceptado
+/// puede igual terminar en `ResponseDeserializationFailed`.
+#[test]
+fn parse_every_live_response() {
+    let dir = dump_dir().join("responses");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        println!("[skip] no hay responses/ todavía");
+        return;
+    };
+    let mut checked = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let case = raw["case"].as_str().unwrap().to_string();
+        let body = raw["response"].clone();
+        let http = raw["http"].as_u64().unwrap_or(0);
+        let kind = body["type"].as_str().unwrap_or("");
+        let result: Result<String, String> = if http != 200 {
+            serde_json::from_value::<fiservemea::FiservemeaErrorResponse>(body.clone())
+                .map(|_| "FiservemeaErrorResponse".to_string())
+                .map_err(|e| e.to_string())
+        } else if kind == "orderResponse" || kind == "transactionResponse" {
+            serde_json::from_value::<fiservemea::FiservemeaSyncResponse>(body.clone())
+                .map(|_| "FiservemeaSyncResponse".to_string())
+                .map_err(|e| e.to_string())
+        } else if kind == "paymentTokenizationResponse" {
+            serde_json::from_value::<fiservemea::FiservemeaTokenResponse>(body.clone())
+                .map(|_| "FiservemeaTokenResponse".to_string())
+                .map_err(|e| e.to_string())
+        } else {
+            serde_json::from_value::<fiservemea::FiservemeaPaymentsResponse>(body.clone())
+                .map(|_| "FiservemeaPaymentsResponse".to_string())
+                .map_err(|e| e.to_string())
+        };
+        match result {
+            Ok(as_type) => println!("[parse ok] {case} ({http}) -> {as_type}"),
+            Err(err) => panic!("[parse FALLA] {case} ({http}) type={kind}: {err}\n{body:#}"),
+        }
+        checked += 1;
+    }
+    println!("[parse] {checked} respuestas reales verificadas");
+    assert!(checked > 0, "no se verificó ninguna respuesta");
+}
+
+/// Pre-auth + captura + anulación de pre-auth. No están en el checklist de homologación pero sí
+/// en el conector (`capture_method: Manual` -> `PaymentCardPreAuthTransaction`), y un rechazo acá
+/// también sería bloqueante. Los cuerpos de captura/anulación no dependen del `ipgTransactionId`
+/// (va en la URL), así que se dumpean como plantilla.
+#[test]
+fn dump_phase7_preauth_capture() {
+    use hyperswitch_domain_models::{
+        router_flow_types::payments::Capture, router_request_types::PaymentsCaptureData,
+    };
+
+    // pre-auth: capture_method Manual
+    let oid = order_id("preauth");
+    let mut request = authorize_data("5165850000000008", enums::Currency::ARS, 100_000, None, false);
+    request.capture_method = Some(enums::CaptureMethod::Manual);
+    let rd: RouterData<Authorize, _, _> = router_data(request, STORE_AR, &oid, false, None);
+    let amount = crate::utils::convert_amount(
+        Fiservemea::new().amount_converter,
+        rd.request.minor_amount,
+        rd.request.currency,
+    )
+    .unwrap();
+    let crd = fiservemea::FiservemeaRouterData::from((amount.clone(), &rd));
+    let req = fiservemea::FiservemeaPaymentsRequest::try_from(&crd).unwrap();
+    dump("preauth", "POST", "/payments", RequestContent::Json(Box::new(req)));
+
+    // segundo pre-auth, para probar la anulación de un pre-auth sin capturar
+    let oid2 = order_id("preauth-void");
+    let mut request2 =
+        authorize_data("5165850000000008", enums::Currency::ARS, 100_000, None, false);
+    request2.capture_method = Some(enums::CaptureMethod::Manual);
+    let rd2: RouterData<Authorize, _, _> = router_data(request2, STORE_AR, &oid2, false, None);
+    let crd2 = fiservemea::FiservemeaRouterData::from((amount.clone(), &rd2));
+    let req2 = fiservemea::FiservemeaPaymentsRequest::try_from(&crd2).unwrap();
+    dump("preauth-void", "POST", "/payments", RequestContent::Json(Box::new(req2)));
+
+    // captura
+    let capture_request = PaymentsCaptureData {
+        amount_to_capture: 100_000,
+        currency: enums::Currency::ARS,
+        connector_transaction_id: "TEMPLATE".to_string(),
+        payment_amount: 100_000,
+        multiple_capture_data: None,
+        connector_meta: None,
+        browser_info: None,
+        metadata: None,
+        capture_method: Some(enums::CaptureMethod::Manual),
+        minor_payment_amount: MinorUnit::new(100_000),
+        minor_amount_to_capture: MinorUnit::new(100_000),
+        integrity_object: None,
+        webhook_url: None,
+        split_payments: None,
+    };
+    let crd3: RouterData<Capture, _, PaymentsResponseData> =
+        router_data(capture_request, STORE_AR, "capture", false, None);
+    let crd3 = fiservemea::FiservemeaRouterData::from((amount, &crd3));
+    let cap = fiservemea::FiservemeaCaptureRequest::try_from(&crd3).unwrap();
+    dump(
+        "tmpl-capture",
+        "POST",
+        "/payments/{ipg}",
+        RequestContent::Json(Box::new(cap)),
+    );
+
+    // anulación de un pre-auth sin capturar
+    let cancel_request = PaymentsCancelData {
+        amount: Some(100_000),
+        currency: Some(enums::Currency::ARS),
+        connector_transaction_id: "TEMPLATE".to_string(),
+        cancellation_reason: None,
+        connector_meta: None,
+        browser_info: None,
+        metadata: None,
+        minor_amount: Some(MinorUnit::new(100_000)),
+        webhook_url: None,
+        capture_method: Some(enums::CaptureMethod::Manual),
+    };
+    let rd4: RouterData<Void, _, _> =
+        router_data(cancel_request, STORE_AR, "void-preauth", false, None);
+    let v = fiservemea::FiservemeaVoidRequest::try_from(&rd4).unwrap();
+    dump(
+        "tmpl-void-preauth",
+        "POST",
+        "/payments/{ipg}",
+        RequestContent::Json(Box::new(v)),
+    );
+}
+
+/// URL de consulta que el conector arma con `build_sync_url`. Es la que usa el PSync y, sobre
+/// todo, la que usa el CompleteAuthorize cuando el callback es la notificación del 3DSMethod
+/// (ahí el conector degrada el PATCH a un GET). `IPGID` se sustituye por el id real.
+#[test]
+fn dump_phase6_sync_urls() {
+    use hyperswitch_domain_models::router_request_types::ResponseId;
+    let by_txn = super::build_sync_url(
+        "https://cert.api.firstdata.com/gateway/v2",
+        &ResponseId::ConnectorTransactionId("IPGID".to_string()),
+        "ORDERID",
+        STORE_AR,
+    )
+    .unwrap();
+    let by_order = super::build_sync_url(
+        "https://cert.api.firstdata.com/gateway/v2",
+        &ResponseId::NoResponseId,
+        "ORDERID",
+        STORE_AR,
+    )
+    .unwrap();
+    let strip = |url: String| {
+        url.trim_start_matches("https://cert.api.firstdata.com/gateway/v2")
+            .to_string()
+    };
+    write_case("tmpl-sync-by-transaction", "GET", &strip(by_txn), None);
+    write_case("tmpl-sync-by-order", "GET", &strip(by_order), None);
+}
+
+/// Cuarta fase: void y refund sobre una transacción aprobada real. Los ids los deja Python.
+#[test]
+fn dump_phase4_void_refund() {
+    let dir = dump_dir();
+    let mut targets: HashMap<String, String> = HashMap::new();
+    if let Ok(raw) = std::fs::read_to_string(dir.join("post_ops.json")) {
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        for (k, val) in v.as_object().unwrap() {
+            targets.insert(k.clone(), val.as_str().unwrap().to_string());
+        }
+    } else {
+        println!("[skip] no hay post_ops.json todavía");
+        return;
+    }
+
+    if let Some(ipg) = targets.get("void") {
+        let request = PaymentsCancelData {
+            amount: Some(100_000),
+            currency: Some(enums::Currency::ARS),
+            connector_transaction_id: ipg.clone(),
+            cancellation_reason: None,
+            connector_meta: None,
+            browser_info: None,
+            metadata: None,
+            minor_amount: Some(MinorUnit::new(100_000)),
+            webhook_url: None,
+            capture_method: Some(enums::CaptureMethod::Automatic),
+        };
+        let rd: RouterData<Void, _, _> = router_data(request, STORE_AR, "void-op", false, None);
+        let req = fiservemea::FiservemeaVoidRequest::try_from(&rd).unwrap();
+        dump(
+            "void",
+            "POST",
+            &format!("/payments/{ipg}"),
+            RequestContent::Json(Box::new(req)),
+        );
+    }
+
+    for (key, amount_minor) in [("return-total", 100_000_i64), ("return-parcial", 50_000)] {
+        if let Some(ipg) = targets.get(key) {
+            let request = RefundsData {
+                refund_id: key.to_string(),
+                connector_transaction_id: ipg.clone(),
+                connector_refund_id: None,
+                currency: enums::Currency::ARS,
+                payment_amount: 100_000,
+                reason: None,
+                webhook_url: None,
+                refund_amount: amount_minor,
+                connector_metadata: None,
+                refund_connector_metadata: None,
+                browser_info: None,
+                split_refunds: None,
+                minor_payment_amount: MinorUnit::new(100_000),
+                minor_refund_amount: MinorUnit::new(amount_minor),
+                integrity_object: None,
+                refund_status: enums::RefundStatus::Pending,
+                merchant_account_id: None,
+                merchant_config_currency: None,
+                capture_method: Some(enums::CaptureMethod::Automatic),
+                additional_payment_method_data: None,
+            };
+            let rd: RouterData<Execute, _, _> = router_data(request, STORE_AR, key, false, None);
+            let amount = crate::utils::convert_amount(
+                Fiservemea::new().amount_converter,
+                rd.request.minor_refund_amount,
+                rd.request.currency,
+            )
+            .unwrap();
+            let crd = fiservemea::FiservemeaRouterData::from((amount, &rd));
+            let req = fiservemea::FiservemeaRefundRequest::try_from(&crd).unwrap();
+            dump(
+                key,
+                "POST",
+                &format!("/payments/{ipg}"),
+                RequestContent::Json(Box::new(req)),
+            );
+        }
+    }
+}

--- a/crates/hyperswitch_connectors/src/connectors/fiservemea/cert_responses.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea/cert_responses.rs
@@ -1,0 +1,2221 @@
+//! Tests de PARSEO de las respuestas REALES del gateway de certificación de Fiserv IPG.
+//!
+//! Todos los payloads de este módulo son cuerpos que el gateway devolvió de verdad, copiados de
+//! la evidencia de homologación (`fiserv_homologacion_logs/*/evidencia.jsonl`, 579 respuestas) o
+//! traídos en vivo de `https://cert.api.firstdata.com/gateway/v2`. Cada fixture dice de dónde
+//! salió y con qué `apiTraceId`.
+//!
+//! A diferencia de los tests del módulo `transformers`, que ejercitan `map_status` sobre los
+//! campos ya deserializados, acá la respuesta cruda pasa por **todo** el camino de conversión
+//! (`serde` -> `TryFrom<ResponseRouterData<..>>` / `build_error_response`) y se verifica lo que
+//! termina viendo Hyperswitch: `AttemptStatus`, `Ok`/`Err`, código y mensaje de error,
+//! `connector_transaction_id`, `network_txn_id`, `connector_metadata` y `mandate_reference`.
+//!
+//! Se corre con:
+//!   cargo test -p hyperswitch_connectors --lib --features v1 fiservemea::cert_responses
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::print_stderr
+)]
+
+use std::marker::PhantomData;
+
+use common_enums::enums;
+use hyperswitch_domain_models::{
+    payment_address::PaymentAddress,
+    router_data::{ConnectorAuthType, ErrorResponse, RouterData},
+    router_request_types::ResponseId,
+    router_response_types::{PaymentsResponseData, RedirectForm},
+};
+use hyperswitch_interfaces::{api::ConnectorCommon, types::Response};
+use masking::{PeekInterface, Secret};
+use serde_json::json;
+
+use super::transformers as fiservemea;
+use crate::{connectors::Fiservemea, types::ResponseRouterData};
+
+/// `RouterData` mínimo. La conversión de respuesta es genérica en `Flow`/`Request`
+/// (`impl<F, T> TryFrom<ResponseRouterData<F, FiservemeaPaymentsResponse, T, PaymentsResponseData>>`),
+/// así que se instancia con `()` en los dos: no hace falta armar un request de ningún flujo para
+/// ejercitar el parseo de la respuesta, que es lo único que se mide acá.
+type TestRouterData = RouterData<(), (), PaymentsResponseData>;
+
+fn empty_router_data<F>() -> RouterData<F, (), PaymentsResponseData> {
+    RouterData {
+        flow: PhantomData,
+        merchant_id: common_utils::id_type::MerchantId::default(),
+        customer_id: None,
+        connector_customer: None,
+        connector: "fiservemea".to_string(),
+        payment_id: "pay_cert".to_string(),
+        attempt_id: "att_cert".to_string(),
+        tenant_id: common_utils::id_type::TenantId::try_from_string("public".to_string()).unwrap(),
+        status: enums::AttemptStatus::Pending,
+        payment_method: enums::PaymentMethod::Card,
+        connector_auth_type: ConnectorAuthType::SignatureKey {
+            api_key: Secret::new("key".to_string()),
+            key1: Secret::new("store".to_string()),
+            api_secret: Secret::new("secret".to_string()),
+        },
+        description: None,
+        address: PaymentAddress::default(),
+        auth_type: enums::AuthenticationType::NoThreeDs,
+        connector_meta_data: None,
+        connector_wallets_details: None,
+        amount_captured: None,
+        access_token: None,
+        session_token: None,
+        reference_id: None,
+        payment_method_token: None,
+        recurring_mandate_payment_data: None,
+        preprocessing_id: None,
+        payment_method_balance: None,
+        connector_api_version: None,
+        request: (),
+        response: Err(ErrorResponse::default()),
+        connector_request_reference_id: "ref_cert".to_string(),
+        #[cfg(feature = "payouts")]
+        payout_method_data: None,
+        #[cfg(feature = "payouts")]
+        quote_id: None,
+        test_mode: Some(true),
+        connector_http_status_code: None,
+        external_latency: None,
+        apple_pay_flow: None,
+        frm_metadata: None,
+        dispute_id: None,
+        refund_id: None,
+        connector_response: None,
+        payment_method_status: None,
+        minor_amount_captured: None,
+        minor_amount_capturable: None,
+        integrity_check: Ok(()),
+        additional_merchant_data: None,
+        header_payload: None,
+        connector_mandate_request_reference_id: None,
+        l2_l3_data: None,
+        authentication_id: None,
+        psd2_sca_exemption_type: None,
+        raw_connector_response: None,
+        is_payment_id_from_merchant: None,
+    }
+}
+
+/// Camino completo de una respuesta 2xx de pago: deserializa y convierte.
+///
+/// El `expect` sobre el `from_value` es el test de deserialización: si alguna respuesta real del
+/// gateway no parseara, el fallo se ve acá con el payload que lo produjo.
+fn convert(raw: serde_json::Value, http_code: u16) -> TestRouterData {
+    let response: fiservemea::FiservemeaPaymentsResponse = serde_json::from_value(raw.clone())
+        .unwrap_or_else(|err| panic!("la respuesta real del gateway no deserializó: {err}\n{raw:#}"));
+    RouterData::try_from(ResponseRouterData {
+        response,
+        data: empty_router_data::<()>(),
+        http_code,
+    })
+    .expect("la conversión de una respuesta real no debe fallar")
+}
+
+/// Camino del PSync: discrimina por `type` entre `transactionResponse` y `orderResponse`, reduce a
+/// una transacción y recién después convierte, igual que `handle_response` del PSync.
+fn convert_sync(raw: serde_json::Value, http_code: u16) -> TestRouterData {
+    let sync: fiservemea::FiservemeaSyncResponse = serde_json::from_value(raw.clone())
+        .unwrap_or_else(|err| panic!("la respuesta real del PSync no deserializó: {err}\n{raw:#}"));
+    let response = sync.into_transaction().expect("orden sin transacciones");
+    RouterData::try_from(ResponseRouterData {
+        response,
+        data: empty_router_data::<()>(),
+        http_code,
+    })
+    .expect("la conversión de una respuesta real de PSync no debe fallar")
+}
+
+/// Camino de las respuestas NO-2xx: el router manda todo lo que no sea 2xx a `get_error_response`
+/// (crates/router/src/services/api.rs, brazo `Err(body)`), que en este conector es
+/// `build_error_response`. Los 107 rechazos con HTTP 409/400 de la evidencia pasan por acá y NO
+/// por el `TryFrom` de `FiservemeaPaymentsResponse`.
+fn error_response(raw: serde_json::Value, status_code: u16) -> ErrorResponse {
+    Fiservemea::new()
+        .build_error_response(
+            Response {
+                headers: None,
+                response: serde_json::to_vec(&raw).unwrap().into(),
+                status_code,
+            },
+            None,
+        )
+        .expect("un rechazo real del gateway debe parsear")
+}
+
+fn transaction_response(data: &TestRouterData) -> &PaymentsResponseData {
+    data.response
+        .as_ref()
+        .unwrap_or_else(|err| panic!("se esperaba Ok, salió Err: {err:?}"))
+}
+
+/// Desarma el `PaymentsResponseData::TransactionResponse` en los campos que interesan acá.
+struct Parsed<'a> {
+    resource_id: &'a ResponseId,
+    redirection: &'a Option<RedirectForm>,
+    mandate_id: Option<&'a String>,
+    metadata: &'a Option<serde_json::Value>,
+    network_txn_id: &'a Option<String>,
+    reference_id: &'a Option<String>,
+}
+
+fn parsed(data: &TestRouterData) -> Parsed<'_> {
+    match transaction_response(data) {
+        PaymentsResponseData::TransactionResponse {
+            resource_id,
+            redirection_data,
+            mandate_reference,
+            connector_metadata,
+            network_txn_id,
+            connector_response_reference_id,
+            ..
+        } => Parsed {
+            resource_id,
+            redirection: redirection_data,
+            mandate_id: mandate_reference
+                .as_ref()
+                .as_ref()
+                .and_then(|reference| reference.connector_mandate_id.as_ref()),
+            metadata: connector_metadata,
+            network_txn_id,
+            reference_id: connector_response_reference_id,
+        },
+        other => panic!("se esperaba TransactionResponse, salió {other:?}"),
+    }
+}
+
+fn connector_transaction_id(data: &TestRouterData) -> Option<String> {
+    match parsed(data).resource_id {
+        ResponseId::ConnectorTransactionId(id) => Some(id.clone()),
+        ResponseId::NoResponseId => None,
+        other => panic!("resource_id inesperado: {other:?}"),
+    }
+}
+
+// =============================================================================================
+//  Fixtures: cuerpos REALES del gateway de certificación, verbatim.
+//
+//  Generados a partir de `fiserv_homologacion_logs/*/evidencia.jsonl` y de consultas en vivo a
+//  https://cert.api.firstdata.com/gateway/v2. NADA está escrito a mano: cada campo, incluidos
+//  `apiTraceId` y `clientRequestId`, es el que devolvió el gateway. El doc comment de cada
+//  fixture dice de qué corrida/línea salió.
+// =============================================================================================
+
+/// `POST /payments` — venta aprobada de 1000.00 ARS con la Mastercard AR de la guía.
+/// Evidencia 20260806-215656 línea 1, caso "AR SALE 1 pago", `apiTraceId`
+/// anUDKXbyIFesn-w_H27JzQAAA9E.
+fn approved_sale() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "d0479c7c-ed0b-4628-86f4-5d9cdee57a30",
+        "apiTraceId": "anUDKXbyIFesn-w_H27JzQAAA9E",
+        "ipgTransactionId": "84667286258",
+        "orderId": "PX-1786053416-01-sale",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "MASTERCARD",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "516585",
+                    "last4": "0008"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000002",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053416-01-sale",
+        "transactionTime": 1_786_053_417_i64,
+        "approvedAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:943616:4667286258:PPXX:9476656675",
+        "transactionState": "CAPTURED",
+        "processor": {
+            "referenceNumber": "000000019357",
+            "authorizationCode": "943616",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "d6a1a93a-fbfb-4f3d-9246-4ce298bfb9ea"
+    })
+}
+
+/// `POST /payment-tokens` — creación del token de gateway (Hosted Data ID).
+/// Evidencia 20260806-181533 línea 1, caso "AR CREATE TOKEN GW", `apiTraceId`
+/// anTPR6AlKqWK06UtlmLTrAAAA74.
+fn tokenization_response() -> serde_json::Value {
+    json!({
+        "type": "paymentTokenizationResponse",
+        "clientRequestId": "5fd71636-ea19-494d-9a8a-eb6860573105",
+        "apiTraceId": "anTPR6AlKqWK06UtlmLTrAAAA74",
+        "requestStatus": "SUCCESS",
+        "requestTime": 1_786_040_135_003_i64,
+        "country": "Argentina",
+        "paymentToken": {
+            "value": "323106FA-6229-4BE7-B3B7-FDAABAD6CA21",
+            "reusable": true,
+            "declineDuplicates": false,
+            "last4": "0008",
+            "brand": "MASTERCARD",
+            "type": "PAYMENT_CARD"
+        },
+        "orderId": "R-f992fe14-7c6f-410d-b497-24bcd452fe0d",
+        "ipgTransactionId": "84667273490"
+    })
+}
+
+/// `POST /payments` con `paymentToken` — venta en cuotas cobrada con el token de gateway. La
+/// respuesta ECOA el `paymentToken.value`, que es el Hosted Data ID reusable para Card on File.
+/// Evidencia 20260806-215656 línea 16, caso "AR SALE cuotas TOKEN GW", `apiTraceId`
+/// anUDQfEpXVh-8FB-wNPYUQAAA6A.
+fn approved_sale_with_gateway_token() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "b6f60038-24d9-4260-8b76-ac4693a0d4fa",
+        "apiTraceId": "anUDQfEpXVh-8FB-wNPYUQAAA6A",
+        "ipgTransactionId": "84667286313",
+        "orderId": "PX-1786053439-10-tokgw",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "value": "CF49734F-986F-4FD1-8040-9A16657E9B3E",
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "MASTERCARD",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "516585",
+                    "last4": "0008"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000001",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053439-10-tokgw",
+        "transactionTime": 1_786_053_441_i64,
+        "approvedAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:503198:4667286313:PPXX:9476918438",
+        "transactionState": "CAPTURED",
+        "processor": {
+            "referenceNumber": "000000019371",
+            "authorizationCode": "503198",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "fd6c9fca-78d1-4fa3-b302-7c5959f943cb"
+    })
+}
+
+/// `POST /payments` con Network Token de la marca (flujo MTRG OnTheGo, 1 pago). El gateway
+/// sustituyó el PAN: el `bin`/`last4` procesado (432312/7867) NO es el que fondea (462294/2366).
+/// Evidencia 20260806-192716 línea 4, caso "AR SALE TOKEN MTRG 1 pago", `apiTraceId`
+/// anTgGxdinKHsuo_YUYBb-AAAA40.
+fn approved_sale_with_network_token() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "6608736b-9735-4eb7-9f32-6e1bf1309236",
+        "apiTraceId": "anTgGxdinKHsuo_YUYBb-AAAA40",
+        "ipgTransactionId": "84667279454",
+        "orderId": "PX-1786044441-03-mtrg",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "462294",
+                    "last4": "2366"
+                },
+                "bin": "432312",
+                "last4": "7867",
+                "brand": "VISA"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "terminalId": "98000001",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786044441-03-mtrg",
+        "transactionTime": 1_786_044_443_i64,
+        "approvedAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:459498:4667279454:PPXX:9437378384",
+        "transactionState": "CAPTURED",
+        "processor": {
+            "referenceNumber": "000000018480",
+            "authorizationCode": "459498",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "a0623fcb-6b16-4e05-9fd7-553170ac9b9a"
+    })
+}
+
+/// `POST /payments` 3DS Frictionless **Authenticated**: aprobada con `responseCode3dSecure: "1"`.
+/// Evidencia 20260806-215656 línea 19, caso "3DS Frictionless Authenticated [init]", `apiTraceId`
+/// anUDSfEpXVh-8FB-wNPYZgAAA7M.
+fn frictionless_authenticated() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "f4b82e47-a010-4d7b-be34-140383f1b52c",
+        "apiTraceId": "anUDSfEpXVh-8FB-wNPYZgAAA7M",
+        "ipgTransactionId": "84667286316",
+        "orderId": "PX-1786053447-13-3ds-fric-y",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "414746",
+                    "last4": "0083"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "414746",
+                "last4": "0083",
+                "brand": "VISA",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "Singapore",
+        "terminalId": "98000003",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053447-13-3ds-fric-y",
+        "transactionTime": 1_786_053_451_i64,
+        "approvedAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:594622:4667286316:PPXX:9476976645",
+        "transactionState": "CAPTURED",
+        "secure3dResponse": {
+            "responseCode3dSecure": "1"
+        },
+        "processor": {
+            "referenceNumber": "000000019373",
+            "authorizationCode": "594622",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "f1aedeb7-a315-4747-a508-5ba5cc6792aa"
+    })
+}
+
+/// `POST /payments` 3DS **Rejected Authentication** por el flujo 3DSMethod: el gateway APRUEBA el
+/// cobro (HTTP 200, APPROVED/CAPTURED) y sólo informa el rechazo de la autenticación en
+/// `secure3dResponse.responseCode3dSecure: "6"`. Además viene con sustitución por Network Token
+/// (bin 441591 procesado vs 401636 que fondea). Evidencia 20260806-215656 línea 30, caso
+/// "3DS 3DSMethod Rejected Authentication [init]", `apiTraceId` anUDdW3QaeZP532udpl7ugAAA7s.
+fn three_ds_rejected_but_approved() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "67b3abfc-28bc-4443-8559-0c8c292985d9",
+        "apiTraceId": "anUDdW3QaeZP532udpl7ugAAA7s",
+        "ipgTransactionId": "84667286430",
+        "orderId": "PX-1786053491-21-3ds-mth-r",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "401636",
+                    "last4": "0085"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "441591",
+                "last4": "0153",
+                "brand": "VISA",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "Singapore",
+        "terminalId": "98000003",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053491-21-3ds-mth-r",
+        "transactionTime": 1_786_053_493_i64,
+        "approvedAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:277699:4667286430:PPXX:9477696647",
+        "transactionState": "CAPTURED",
+        "secure3dResponse": {
+            "responseCode3dSecure": "6",
+            "transactionStatusReason": "8"
+        },
+        "processor": {
+            "referenceNumber": "000000019381",
+            "authorizationCode": "277699",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "7b5c2dbc-3654-452a-8163-5318beac2995"
+    })
+}
+
+/// `POST /payments` 3DS, primer paso: `WAITING` en los tres campos de estado y un
+/// `secure3dMethod.methodForm` para el fingerprint del emisor. Evidencia 20260806-215656 línea 24,
+/// caso "3DS 3DSMethod Authenticated [init]", `apiTraceId` anUDWRdinKHsuo_YUYCB_QAAA48.
+fn waiting_with_three_ds_method() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "5bf8c7fd-20a1-4b44-980e-a26fe2929a22",
+        "apiTraceId": "anUDWRdinKHsuo_YUYCB_QAAA48",
+        "ipgTransactionId": "84667286332",
+        "orderId": "PX-1786053463-18-3ds-mth-y",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "409900",
+                    "last4": "1978"
+                },
+                "cardFunction": "DEBIT",
+                "bin": "409900",
+                "last4": "1978",
+                "brand": "VISA"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "India",
+        "merchantTransactionId": "PX-1786053463-18-3ds-mth-y",
+        "transactionTime": 1_786_053_466_i64,
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "WAITING",
+        "transactionResult": "WAITING",
+        "approvalCode": "?:waiting 3dsecureMethod",
+        "transactionState": "WAITING",
+        "authenticationResponse": {
+            "type": "3D_SECURE",
+            "version": "2.2",
+            "secure3dMethod": {
+                "methodForm": "<iframe id=\"tdsMmethodTgtFrame\" name=\"tdsMmethodTgtFrame\" style=\"visibility: hidden; width: 1px; height: 1px;\" xmlns=\"http://www.w3.org/1999/xhtml\">    <!--.--></iframe><form id=\"tdsMmethodForm\" name=\"tdsMmethodForm\" action=\"https://3ds-acs.test.modirum.com/mdpayacs/3ds-method\" method=\"post\" target=\"tdsMmethodTgtFrame\" xmlns=\"http://www.w3.org/1999/xhtml\">    <input type=\"hidden\" name=\"3DSMethodData\" value=\"eyAidGhyZWVEU1NlcnZlclRyYW5zSUQiIDogImVkMjNkYzI4LTRkYmMtNTBlMC04MDAwLTAwMDAwNDRmNzhmMyIsICJ0aHJlZURTTWV0aG9kTm90aWZpY2F0aW9uVVJMIiA6ICJodHRwczovL3d3dy5weHNvbC5jb20vM2RzL21ldGhvZD9yZWY9UFgtMTc4NjA1MzQ2My0xOC0zZHMtbXRoLXkiIH0\"/>    <input type=\"hidden\" name=\"threeDSMethodData\" value=\"eyAidGhyZWVEU1NlcnZlclRyYW5zSUQiIDogImVkMjNkYzI4LTRkYmMtNTBlMC04MDAwLTAwMDAwNDRmNzhmMyIsICJ0aHJlZURTTWV0aG9kTm90aWZpY2F0aW9uVVJMIiA6ICJodHRwczovL3d3dy5weHNvbC5jb20vM2RzL21ldGhvZD9yZWY9UFgtMTc4NjA1MzQ2My0xOC0zZHMtbXRoLXkiIH0\"/>    <script type=\"text/javascript\">\t\t\t\tdocument.getElementById(\"tdsMmethodForm\").submit();\t\t\t</script></form>",
+                "secure3dTransId": "72317171"
+            }
+        },
+        "globallyUniqueIdentifier": "8df6c8c4-c1e5-4210-b95d-16697cdc2799"
+    })
+}
+
+/// `POST /payments` 3DS, paso de desafío: `WAITING` con `params` para postear al ACS.
+///
+/// El gateway de cert **no** manda `sessionData` en este bloque (verificado sobre las 76
+/// respuestas con `params` de la evidencia): sólo `acsURL`, `cReq` y `termURL`. Evidencia
+/// 20260806-215656 línea 33, caso "3DS Challenge - R [init]", `apiTraceId`
+/// anUDfvEpXVh-8FB-wNPZowAAA60.
+fn waiting_with_challenge_params() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "2c35f767-0beb-40c2-ab4a-d3aa4e1e8063",
+        "apiTraceId": "anUDfvEpXVh-8FB-wNPZowAAA60",
+        "ipgTransactionId": "84667286470",
+        "orderId": "PX-1786053500-23-3ds-cha-r",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "414746",
+                    "last4": "0034"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "414746",
+                "last4": "0034",
+                "brand": "VISA",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "Singapore",
+        "merchantTransactionId": "PX-1786053500-23-3ds-cha-r",
+        "transactionTime": 1_786_053_503_i64,
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "WAITING",
+        "transactionResult": "WAITING",
+        "approvalCode": "?:waiting 3dsecure",
+        "transactionState": "WAITING",
+        "authenticationResponse": {
+            "type": "3D_SECURE",
+            "version": "2.2",
+            "params": {
+                "termURL": "https://www.pxsol.com/3ds/return?ref=PX-1786053500-23-3ds-cha-r",
+                "acsURL": "https://3ds-acs.test.modirum.com/mdpayacs/creq;token=377138781.1786053503.T6iezYS8mm-1VUzwEOLZaNsthnKNMdqTYCk6tIxJ0PE",
+                "cReq": "ewogICAgImFjc1RyYW5zSUQiOiAiMzRmZDc5YzAtZTlkYS00MTY5LWE1NjItOGE0MmE3MDFkNjYyIiwKICAgICJjaGFsbGVuZ2VXaW5kb3dTaXplIjogIjA1IiwKICAgICJtZXNzYWdlVHlwZSI6ICJDUmVxIiwKICAgICJtZXNzYWdlVmVyc2lvbiI6ICIyLjIuMCIsCiAgICAidGhyZWVEU1NlcnZlclRyYW5zSUQiOiAiMjVjZGJiODktZTBkYS01M2ViLTgwMDAtMDAwMDA0NGY3OTQzIgp9"
+            }
+        },
+        "globallyUniqueIdentifier": "7744fa73-770f-4387-97e1-55ba678f6614"
+    })
+}
+
+/// `POST /payments/{id}` — anulación aprobada. Devuelve un `ipgTransactionId` NUEVO (el de la
+/// transacción VOID) y `transactionType: VOID`. Evidencia 20260806-215656 línea 10, caso
+/// "AR VOID (anulación)", `apiTraceId` anUDNnbyIFesn-w_H27KIAAAA9A.
+fn approved_void() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "88d88a30-a92d-4b4f-bc47-817c4a756f7a",
+        "apiTraceId": "anUDNnbyIFesn-w_H27KIAAAA9A",
+        "ipgTransactionId": "84667286297",
+        "orderId": "PX-1786053427-07-void",
+        "transactionType": "VOID",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "MASTERCARD",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "516585",
+                    "last4": "0008"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000002",
+        "merchantId": "00000014",
+        "transactionTime": 1_786_053_430_i64,
+        "approvedAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionStatus": "APPROVED",
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:470405:4667286297:PPXX:9476816680",
+        "transactionState": "VOIDED",
+        "processor": {
+            "referenceNumber": "000000019365",
+            "authorizationCode": "470405",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "752d6538-9bb9-404e-8e6f-3afbfde0f8e3"
+    })
+}
+
+/// `GET /payments/{id}?storeId=...` — consulta de una venta aprobada. **No trae
+/// `transactionStatus`**: el estado sale de `transactionResult` + `transactionType`. Es la forma
+/// de las 12 respuestas de INQUIRY de la evidencia. Evidencia 20260806-215656 línea 7, caso
+/// "AR INQUIRY by transactionId", `apiTraceId` anUDMnbyIFesn-w_H27J_QAAA-Y.
+fn sync_approved_sale() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "3940f40b-e666-4a3a-9186-fa647f48bfc1",
+        "apiTraceId": "anUDMnbyIFesn-w_H27J_QAAA-Y",
+        "ipgTransactionId": "84667286294",
+        "orderId": "PX-1786053423-06-inq",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "last4": "0008",
+            "brand": "MASTERCARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000002",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053423-06-inq",
+        "transactionTime": 1_786_053_424_i64,
+        "approvedAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:412380:4667286294:PPXX:9476776678",
+        "transactionState": "CAPTURED",
+        "processor": {
+            "referenceNumber": "000000019363",
+            "authorizationCode": "412380",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED"
+        },
+        "globallyUniqueIdentifier": "eb400f16-0fcd-407c-805f-3134db9894ce"
+    })
+}
+
+/// `GET /orders/{orderId}?storeId=...` — consulta por orden: los datos van dentro de
+/// `transactions`. Evidencia 20260806-215656 línea 8, caso "AR INQUIRY ORDER", `apiTraceId`
+/// anUDM3byIFesn-w_H27KCQAAA90.
+fn sync_order_response() -> serde_json::Value {
+    json!({
+        "type": "orderResponse",
+        "clientRequestId": "6f5a66d2-eb70-4b80-82b1-c921bebeea58",
+        "apiTraceId": "anUDM3byIFesn-w_H27KCQAAA90",
+        "orderId": "PX-1786053423-06-inq",
+        "transactions": [
+            {
+                "type": "transactionResponse",
+                "ipgTransactionId": "84667286294",
+                "transactionType": "SALE",
+                "paymentToken": {
+                    "last4": "0008",
+                    "brand": "MASTERCARD"
+                },
+                "transactionOrigin": "ECOM",
+                "paymentMethodDetails": {
+                    "paymentCard": {
+                        "expiryDate": {
+                            "month": "12",
+                            "year": "2029"
+                        },
+                        "cardFunction": "CREDIT",
+                        "bin": "516585",
+                        "last4": "0008",
+                        "brand": "MASTERCARD"
+                    },
+                    "paymentMethodType": "PAYMENT_CARD",
+                    "paymentMethodBrand": "MASTERCARD"
+                },
+                "country": "Argentina",
+                "terminalId": "98000002",
+                "merchantId": "00000014",
+                "merchantTransactionId": "PX-1786053423-06-inq",
+                "transactionTime": 1_786_053_424_i64,
+                "approvedAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionResult": "APPROVED",
+                "approvalCode": "Y:412380:4667286294:PPXX:9476776678",
+                "transactionState": "CAPTURED",
+                "processor": {
+                    "referenceNumber": "000000019363",
+                    "authorizationCode": "412380",
+                    "responseCode": "00",
+                    "responseMessage": "Function performed error-free",
+                    "avsResponse": {
+                        "streetMatch": "NO_INPUT_DATA",
+                        "postalCodeMatch": "NO_INPUT_DATA"
+                    },
+                    "securityCodeResponse": "NOT_CHECKED"
+                },
+                "globallyUniqueIdentifier": "eb400f16-0fcd-407c-805f-3134db9894ce"
+            }
+        ]
+    })
+}
+
+/// `GET /orders/{orderId}?storeId=...` sobre la orden de una venta ANULADA.
+///
+/// Traído en vivo del gateway de cert el 2026-08-13 (`apiTraceId` an0QkyR5qsxv6kPs1WoIvAAAAdk).
+/// Dos transacciones: primero la SALE, después el VOID. La SALE llega
+/// `transactionResult: APPROVED` / `transactionType: SALE` y el único campo que dice que la plata
+/// se liberó es `transactionState: VOIDED`.
+fn sync_order_of_a_voided_sale() -> serde_json::Value {
+    json!({
+        "type": "orderResponse",
+        "clientRequestId": "0233f9b0-2dfc-4ad9-9eea-04bdc5e46d82",
+        "apiTraceId": "an0QkyR5qsxv6kPs1WoIvAAAAdk",
+        "orderId": "PX-1786053427-07-void",
+        "transactions": [
+            {
+                "type": "transactionResponse",
+                "ipgTransactionId": "84667286296",
+                "transactionType": "SALE",
+                "paymentToken": {
+                    "last4": "0008",
+                    "brand": "MASTERCARD"
+                },
+                "transactionOrigin": "ECOM",
+                "paymentMethodDetails": {
+                    "paymentCard": {
+                        "expiryDate": {
+                            "month": "12",
+                            "year": "2029"
+                        },
+                        "cardFunction": "CREDIT",
+                        "bin": "516585",
+                        "last4": "0008",
+                        "brand": "MASTERCARD"
+                    },
+                    "paymentMethodType": "PAYMENT_CARD",
+                    "paymentMethodBrand": "MASTERCARD"
+                },
+                "country": "Argentina",
+                "terminalId": "98000002",
+                "merchantId": "00000014",
+                "merchantTransactionId": "PX-1786053427-07-void",
+                "transactionTime": 1_786_053_429_i64,
+                "approvedAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionResult": "APPROVED",
+                "approvalCode": "Y:986494:4667286296:PPXX:9476796679",
+                "transactionState": "VOIDED",
+                "processor": {
+                    "referenceNumber": "000000019364",
+                    "authorizationCode": "986494",
+                    "responseCode": "00",
+                    "responseMessage": "Function performed error-free",
+                    "avsResponse": {
+                        "streetMatch": "NO_INPUT_DATA",
+                        "postalCodeMatch": "NO_INPUT_DATA"
+                    },
+                    "securityCodeResponse": "NOT_CHECKED"
+                },
+                "globallyUniqueIdentifier": "ae96ccd1-b53e-4687-939c-a5a02bc67679"
+            },
+            {
+                "type": "transactionResponse",
+                "ipgTransactionId": "84667286297",
+                "transactionType": "VOID",
+                "paymentToken": {
+                    "last4": "0008",
+                    "brand": "MASTERCARD"
+                },
+                "transactionOrigin": "ECOM",
+                "paymentMethodDetails": {
+                    "paymentCard": {
+                        "expiryDate": {
+                            "month": "12",
+                            "year": "2029"
+                        },
+                        "cardFunction": "CREDIT",
+                        "bin": "516585",
+                        "last4": "0008",
+                        "brand": "MASTERCARD"
+                    },
+                    "paymentMethodType": "PAYMENT_CARD",
+                    "paymentMethodBrand": "MASTERCARD"
+                },
+                "country": "Argentina",
+                "terminalId": "98000002",
+                "merchantId": "00000014",
+                "transactionTime": 1_786_053_430_i64,
+                "approvedAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionAmount": {
+                    "total": 1000,
+                    "currency": "ARS",
+                    "components": {
+                        "subtotal": 1000
+                    }
+                },
+                "transactionResult": "APPROVED",
+                "approvalCode": "Y:470405:4667286296:PPXX:9476816680",
+                "transactionState": "VOIDED",
+                "processor": {
+                    "referenceNumber": "000000019365",
+                    "authorizationCode": "470405",
+                    "responseCode": "00",
+                    "responseMessage": "Function performed error-free",
+                    "avsResponse": {
+                        "streetMatch": "NO_INPUT_DATA",
+                        "postalCodeMatch": "NO_INPUT_DATA"
+                    },
+                    "securityCodeResponse": "NOT_CHECKED"
+                },
+                "globallyUniqueIdentifier": "752d6538-9bb9-404e-8e6f-3afbfde0f8e3"
+            }
+        ]
+    })
+}
+
+/// `GET /payments/84667286296?storeId=...` — consulta de la venta ANULADA por su propio id.
+///
+/// Traído en vivo del gateway de cert el 2026-08-13 (`apiTraceId` an0QkuOTJZTvEmGNMGmHtAAAAvs).
+/// Es la misma trampa que la orden de arriba, pero por el camino principal del PSync:
+/// `transactionResult: APPROVED`, `transactionType: SALE`, sin `transactionStatus`, y
+/// `transactionState: VOIDED`.
+fn sync_of_a_voided_sale() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "bfd2190a-a484-4ad9-9c32-aaae446c04f5",
+        "apiTraceId": "an0QkuOTJZTvEmGNMGmHtAAAAvs",
+        "ipgTransactionId": "84667286296",
+        "orderId": "PX-1786053427-07-void",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "last4": "0008",
+            "brand": "MASTERCARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000002",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053427-07-void",
+        "transactionTime": 1_786_053_429_i64,
+        "approvedAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionResult": "APPROVED",
+        "approvalCode": "Y:986494:4667286296:PPXX:9476796679",
+        "transactionState": "VOIDED",
+        "processor": {
+            "referenceNumber": "000000019364",
+            "authorizationCode": "986494",
+            "responseCode": "00",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED"
+        },
+        "globallyUniqueIdentifier": "ae96ccd1-b53e-4687-939c-a5a02bc67679"
+    })
+}
+
+/// `GET /payments/{id}?storeId=...` — consulta de una venta RECHAZADA por el gateway.
+///
+/// Traído en vivo el 2026-08-13 (`apiTraceId` an0Qlp2Cn6oVn4oVRUTafQAAAxA, transacción
+/// 84667287090, el rechazo 11101 de cuotas). Llega **con HTTP 200**: sin `transactionStatus`, sin
+/// `errorMessage`, y con un bloque `processor` que trae SÓLO `avsResponse` — o sea sin
+/// `responseCode` ni `responseMessage`. El único motivo que sobrevive está en `approvalCode`.
+fn sync_of_a_declined_sale() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "fe5fc865-ea80-4e1b-bb93-8b66f2bbe520",
+        "apiTraceId": "an0Qlp2Cn6oVn4oVRUTafQAAAxA",
+        "ipgTransactionId": "84667287090",
+        "orderId": "PX-1786053663-53-diag",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "last4": "0153",
+            "brand": "VISA"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "bin": "441591",
+                "last4": "0153",
+                "brand": "VISA"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "Singapore",
+        "terminalId": "98000003",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786053663-53-diag",
+        "transactionTime": 1_786_053_664_i64,
+        "transactionAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionResult": "FAILED",
+        "approvalCode": "N:-11101:installment not supported",
+        "transactionState": "DECLINED",
+        "processor": {
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            }
+        },
+        "globallyUniqueIdentifier": "47f4ef64-1941-483c-89dc-e73a7b54e3ee"
+    })
+}
+
+/// `POST /payments` — rechazo del EMISOR con HTTP **422** / `responseType: EndpointDeclined`.
+///
+/// Traído en vivo del gateway de cert el 2026-08-13 (monto 1005.00 ARS con la Mastercard AR;
+/// `apiTraceId` an0Q352Cn6oVn4oVRUTc0QAAAxQ, transacción 84668174890). Es la forma del rechazo
+/// más común en producción, y la única que trae el bloque `processor` completo con el código ISO
+/// del emisor. No está en `evidencia.jsonl` porque el harness no corre este caso.
+fn issuer_decline_422() -> serde_json::Value {
+    json!({
+        "type": "TransactionErrorResponse",
+        "clientRequestId": "8b400364-35a2-447e-8c8b-8a033ad78836",
+        "apiTraceId": "an0Q352Cn6oVn4oVRUTc0QAAAxQ",
+        "responseType": "EndpointDeclined",
+        "ipgTransactionId": "84668174890",
+        "orderId": "PX-1786581214-01-decl422",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "MASTERCARD",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "516585",
+                    "last4": "0008"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000001",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786581214-01-decl422",
+        "transactionTime": 1_786_581_215_i64,
+        "transactionAmount": {
+            "total": 1005.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1005.0
+            }
+        },
+        "transactionStatus": "DECLINED",
+        "transactionResult": "DECLINED",
+        "approvalCode": "N:05:Do not honour",
+        "errorMessage": "50005: Do not honour",
+        "transactionState": "DECLINED",
+        "processor": {
+            "referenceNumber": "000000066269",
+            "authorizationCode": "846443",
+            "responseCode": "05",
+            "responseMessage": "Do not honour",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "taxRefundData": {}
+        },
+        "globallyUniqueIdentifier": "dd848282-c561-44d4-b54e-ab4005c8e6fd",
+        "error": {
+            "code": "50005",
+            "message": "Do not honour"
+        }
+    })
+}
+
+/// `GET /payments/84668174890?storeId=...` — el MISMO rechazo del emisor visto por el PSync.
+///
+/// Traído en vivo el 2026-08-13 (`apiTraceId` an0Q4Xrd5Cb_7xaduYWo5wAAAzo). Llega con **HTTP
+/// 200**, `transactionResult: DECLINED` (no `FAILED`) y —al revés que el PSync de un rechazo del
+/// gateway— con `processor.responseCode` y `responseMessage` completos.
+fn sync_of_an_issuer_declined_sale() -> serde_json::Value {
+    json!({
+        "type": "transactionResponse",
+        "clientRequestId": "f059eac8-4a7f-4656-bc64-f71d2664670f",
+        "apiTraceId": "an0Q4Xrd5Cb_7xaduYWo5wAAAzo",
+        "ipgTransactionId": "84668174890",
+        "orderId": "PX-1786581214-01-decl422",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "last4": "0008",
+            "brand": "MASTERCARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "MASTERCARD"
+        },
+        "country": "Argentina",
+        "terminalId": "98000001",
+        "merchantId": "00000014",
+        "merchantTransactionId": "PX-1786581214-01-decl422",
+        "transactionTime": 1_786_581_215_i64,
+        "transactionAmount": {
+            "total": 1005,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1005
+            }
+        },
+        "transactionResult": "DECLINED",
+        "approvalCode": "N:05:Do not honour",
+        "transactionState": "DECLINED",
+        "processor": {
+            "referenceNumber": "000000066269",
+            "authorizationCode": "846443",
+            "responseCode": "05",
+            "responseMessage": "Do not honour",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            }
+        },
+        "globallyUniqueIdentifier": "dd848282-c561-44d4-b54e-ab4005c8e6fd"
+    })
+}
+
+/// `POST /payments` — rechazo de 3DS con HTTP **409**. Trae `secure3dResponse` con el
+/// `responseCode3dSecure` que explica por qué se cayó la autenticación, y NO trae bloque
+/// `processor`. Evidencia 20260806-215656 línea 22, caso
+/// "3DS Frictionless Rejected Authentication [init]", `apiTraceId` anUDUyKQSojaSWQEaFJT7wAAA9I.
+fn declined_3ds_409() -> serde_json::Value {
+    json!({
+        "type": "TransactionErrorResponse",
+        "clientRequestId": "c256932c-cfd9-457d-9884-3efe69bb66dc",
+        "apiTraceId": "anUDUyKQSojaSWQEaFJT7wAAA9I",
+        "responseType": "GatewayDeclined",
+        "ipgTransactionId": "84667286319",
+        "orderId": "PX-1786053458-16-3ds-fric-r",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "414746",
+                    "last4": "0042"
+                },
+                "cardFunction": "CREDIT",
+                "bin": "414746",
+                "last4": "0042",
+                "brand": "VISA",
+                "commercialCard": "NON_CORPORATE"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "Singapore",
+        "merchantTransactionId": "PX-1786053458-16-3ds-fric-r",
+        "transactionTime": 1_786_053_460_i64,
+        "transactionAmount": {
+            "total": 1000.0,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000.0
+            }
+        },
+        "transactionStatus": "VALIDATION_FAILED",
+        "transactionResult": "FAILED",
+        "approvalCode": "N:-50716:3D Secure authentication failed",
+        "errorMessage": "50716: Transaction declined. 3D Secure authentication failed.",
+        "transactionState": "DECLINED",
+        "secure3dResponse": {
+            "responseCode3dSecure": "3",
+            "transactionStatusReason": "2"
+        },
+        "globallyUniqueIdentifier": "a102adff-a7ac-46b8-b8a6-5e78ddad203e",
+        "error": {
+            "code": "50716",
+            "message": "Transaction declined. 3D Secure authentication failed."
+        }
+    })
+}
+
+/// `PATCH /payments/{id}` — rechazo de 3DS con HTTP 409 en la continuación, con `cardholderInfo`
+/// (el texto que el emisor quiere que se le muestre al comprador). Evidencia 20260806-215656
+/// línea 27, caso "3DS 3DSMethod Not Authenticated [methodNotificationStatus]", `apiTraceId`
+/// anUDbKTdM6YRPnGROVIJJwAAA6k.
+fn declined_3ds_409_with_cardholder_info() -> serde_json::Value {
+    json!({
+        "type": "TransactionErrorResponse",
+        "clientRequestId": "28378a74-8a5a-40a9-8ed8-22619d6a49c5",
+        "apiTraceId": "anUDbKTdM6YRPnGROVIJJwAAA6k",
+        "responseType": "GatewayDeclined",
+        "ipgTransactionId": "84667286333",
+        "orderId": "PX-1786053474-19-3ds-mth-n",
+        "transactionType": "SALE",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "brand": "VISA",
+            "type": "PAYMENT_CARD"
+        },
+        "transactionOrigin": "ECOM",
+        "paymentMethodDetails": {
+            "paymentCard": {
+                "expiryDate": {
+                    "month": "12",
+                    "year": "2029"
+                },
+                "fundingCardNumber": {
+                    "bin": "426588",
+                    "last4": "0015"
+                },
+                "cardFunction": "DEBIT",
+                "bin": "426588",
+                "last4": "0015",
+                "brand": "VISA"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        },
+        "country": "India",
+        "merchantTransactionId": "PX-1786053474-19-3ds-mth-n",
+        "transactionTime": 1_786_053_476_i64,
+        "transactionAmount": {
+            "total": 1000,
+            "currency": "ARS",
+            "components": {
+                "subtotal": 1000
+            }
+        },
+        "transactionStatus": "VALIDATION_FAILED",
+        "transactionResult": "FAILED",
+        "approvalCode": "N:-50716:3D Secure authentication failed",
+        "errorMessage": "50716: Transaction declined. 3D Secure authentication failed.",
+        "transactionState": "DECLINED",
+        "secure3dResponse": {
+            "responseCode3dSecure": "3",
+            "cardholderInfo": "Your card has not been configured to support EMV 3-D Secure, please contact your bank.",
+            "transactionStatusReason": "12"
+        },
+        "globallyUniqueIdentifier": "4d963fe8-6c47-4575-addc-a91ea7a5342a",
+        "error": {
+            "code": "50716",
+            "message": "Transaction declined. 3D Secure authentication failed."
+        }
+    })
+}
+
+/// `POST /payments` — rechazo Data Only con HTTP 409 **sin `ipgTransactionId`**: el gateway falla
+/// antes de crear la transacción. Evidencia 20260806-215656 línea 58, caso
+/// "3DS DataOnly (Mastercard, messageCategory 80) [init]", `apiTraceId`
+/// anUD4RdinKHsuo_YUYCCjQAAA5M.
+fn declined_data_only_without_transaction_id() -> serde_json::Value {
+    json!({
+        "type": "TransactionErrorResponse",
+        "clientRequestId": "496db1e7-352f-46ea-9946-3b1c8c57d2ea",
+        "apiTraceId": "anUD4RdinKHsuo_YUYCCjQAAA5M",
+        "responseType": "GatewayDeclined",
+        "orderId": "PX-1786053599-33-3ds-dataonly",
+        "paymentToken": {
+            "reusable": true,
+            "declineDuplicates": false,
+            "type": "PAYMENT_CARD"
+        },
+        "transactionTime": 1_786_053_601_i64,
+        "transactionStatus": "VALIDATION_FAILED",
+        "transactionResult": "FAILED",
+        "approvalCode": "N:-50655:Unable to verify card enrollment",
+        "errorMessage": "50655: Unable to verify card enrollment",
+        "secure3dResponse": {
+            "responseCode3dSecure": "8"
+        },
+        "error": {
+            "code": "50655",
+            "message": "Unable to verify card enrollment"
+        }
+    })
+}
+
+/// `POST /payments` — HTTP **400** `INVALID_INPUT` con `details`. Es la única respuesta de la
+/// evidencia con `type: errorResponse` y sin `responseType`. Evidencia 20260806-181513 línea 5,
+/// caso "AR DYNAMIC MERCHANT NAME" (cuando el `softDescriptor` todavía iba al nivel equivocado),
+/// `apiTraceId` anTPN3byIFesn-w_H26txgAAA-I.
+fn invalid_input_400() -> serde_json::Value {
+    json!({
+        "type": "errorResponse",
+        "clientRequestId": "84cde100-3a04-485c-afb8-69e1b8ee499e",
+        "apiTraceId": "anTPN3byIFesn-w_H26txgAAA-I",
+        "error": {
+            "code": "INVALID_INPUT",
+            "message": "Invalid request input. Please see details below.",
+            "details": [
+                {
+                    "field": "softDescriptor",
+                    "message": "No field named 'softDescriptor' exists for class PaymentCardSaleTransaction"
+                }
+            ]
+        }
+    })
+}
+
+// =============================================================================================
+//  1. Toda respuesta real deserializa
+// =============================================================================================
+
+#[test]
+fn every_real_payment_response_shape_deserializes() {
+    // Las formas de respuesta de pago que el gateway devolvió en las 579 respuestas capturadas,
+    // una por cada grupo. Si el conector deja de parsear alguna, un cobro real se convierte en
+    // `ResponseDeserializationFailed`.
+    for (name, raw, http) in [
+        ("sale aprobada", approved_sale(), 200),
+        ("sale con token GW", approved_sale_with_gateway_token(), 200),
+        ("sale con network token", approved_sale_with_network_token(), 200),
+        ("3DS frictionless autenticada", frictionless_authenticated(), 200),
+        ("3DS rechazada pero aprobada", three_ds_rejected_but_approved(), 200),
+        ("WAITING con 3DSMethod", waiting_with_three_ds_method(), 200),
+        ("WAITING con params de desafío", waiting_with_challenge_params(), 200),
+        ("void aprobado", approved_void(), 200),
+        ("PSync de venta aprobada", sync_approved_sale(), 200),
+        ("PSync de venta anulada", sync_of_a_voided_sale(), 200),
+        ("PSync de venta rechazada", sync_of_a_declined_sale(), 200),
+        ("409 3DS rechazado", declined_3ds_409(), 409),
+        ("409 3DS con cardholderInfo", declined_3ds_409_with_cardholder_info(), 409),
+        ("409 Data Only sin id", declined_data_only_without_transaction_id(), 409),
+        ("422 rechazo del emisor", issuer_decline_422(), 422),
+        ("PSync del rechazo del emisor", sync_of_an_issuer_declined_sale(), 200),
+    ] {
+        let parsed: Result<fiservemea::FiservemeaPaymentsResponse, _> =
+            serde_json::from_value(raw.clone());
+        assert!(
+            parsed.is_ok(),
+            "{name} no deserializó: {:?}\n{raw:#}",
+            parsed.err()
+        );
+        // Y la conversión completa tampoco puede fallar (el `convert` hace el `expect`).
+        let _ = convert(raw, http);
+    }
+}
+
+#[test]
+fn every_real_sync_response_shape_deserializes() {
+    for (name, raw) in [
+        ("transactionResponse", sync_approved_sale()),
+        ("orderResponse", sync_order_response()),
+        ("orderResponse de una anulación", sync_order_of_a_voided_sale()),
+    ] {
+        let parsed: Result<fiservemea::FiservemeaSyncResponse, _> =
+            serde_json::from_value(raw.clone());
+        assert!(
+            parsed.is_ok(),
+            "{name} no deserializó como FiservemeaSyncResponse: {:?}\n{raw:#}",
+            parsed.err()
+        );
+    }
+}
+
+#[test]
+fn tokenization_response_yields_the_hosted_data_id() {
+    let response: fiservemea::FiservemeaTokenResponse =
+        serde_json::from_value(tokenization_response()).expect("la respuesta real debe parsear");
+    let data: RouterData<
+        hyperswitch_domain_models::router_flow_types::payments::PaymentMethodToken,
+        (),
+        PaymentsResponseData,
+    > = RouterData::try_from(ResponseRouterData {
+        response,
+        data: empty_router_data(),
+        http_code: 200,
+    })
+    .expect("la conversión del token no debe fallar");
+    match data.response.as_ref().unwrap() {
+        PaymentsResponseData::TokenizationResponse { token } => {
+            assert_eq!(token, "323106FA-6229-4BE7-B3B7-FDAABAD6CA21");
+        }
+        other => panic!("se esperaba TokenizationResponse, salió {other:?}"),
+    }
+}
+
+/// Los fixtures de este módulo tienen que ser IDÉNTICOS al cuerpo que el gateway devolvió, no una
+/// versión abreviada ni retocada: cada uno se compara contra la línea exacta de la evidencia de la
+/// que salió. Si alguien edita un fixture "para simplificarlo", este test lo detecta.
+///
+/// Los cuatro fixtures traídos en vivo (`sync_of_a_voided_sale`, `sync_order_of_a_voided_sale`,
+/// `issuer_decline_422`, `sync_of_an_issuer_declined_sale`) no están en la evidencia y no se
+/// pueden verificar acá; su procedencia está en el doc comment de cada uno.
+#[test]
+fn the_fixtures_are_verbatim_copies_of_the_evidence() {
+    let Some(root) = evidence_root() else {
+        return;
+    };
+    #[rustfmt::skip]
+    let expected: [(&str, &str, usize, serde_json::Value); 15] = [
+        ("approved_sale", "20260806-215656", 0, approved_sale()),
+        ("tokenization_response", "20260806-181533", 0, tokenization_response()),
+        ("approved_sale_with_gateway_token", "20260806-215656", 15, approved_sale_with_gateway_token()),
+        ("approved_sale_with_network_token", "20260806-192716", 3, approved_sale_with_network_token()),
+        ("frictionless_authenticated", "20260806-215656", 18, frictionless_authenticated()),
+        ("three_ds_rejected_but_approved", "20260806-215656", 29, three_ds_rejected_but_approved()),
+        ("waiting_with_three_ds_method", "20260806-215656", 23, waiting_with_three_ds_method()),
+        ("waiting_with_challenge_params", "20260806-215656", 32, waiting_with_challenge_params()),
+        ("approved_void", "20260806-215656", 9, approved_void()),
+        ("sync_approved_sale", "20260806-215656", 6, sync_approved_sale()),
+        ("sync_order_response", "20260806-215656", 7, sync_order_response()),
+        ("declined_3ds_409", "20260806-215656", 21, declined_3ds_409()),
+        ("declined_3ds_409_with_cardholder_info", "20260806-215656", 26, declined_3ds_409_with_cardholder_info()),
+        ("declined_data_only_without_transaction_id", "20260806-215656", 57, declined_data_only_without_transaction_id()),
+        ("invalid_input_400", "20260806-181513", 4, invalid_input_400()),
+    ];
+    for (name, run, line_index, fixture) in expected {
+        let path = root.join(run).join("evidencia.jsonl");
+        let file = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("{name}: no se pudo leer {path:?}: {err}"));
+        let line = file
+            .lines()
+            .nth(line_index)
+            .unwrap_or_else(|| panic!("{name}: {path:?} no tiene la línea {line_index}"));
+        let step: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(
+            step["response"], fixture,
+            "el fixture `{name}` dejó de ser el cuerpo real de {run} línea {}",
+            line_index + 1
+        );
+    }
+}
+
+/// Raíz de la evidencia de homologación, o `None` cuando no está (está gitignoreada).
+fn evidence_root() -> Option<std::path::PathBuf> {
+    match std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fiserv_homologacion_logs")
+        .canonicalize()
+    {
+        Ok(root) => Some(root),
+        Err(_) => {
+            eprintln!("evidencia de homologación ausente (gitignoreada); test salteado");
+            None
+        }
+    }
+}
+
+/// Barrido sobre TODA la evidencia de homologación: cada cuerpo que el gateway devolvió alguna
+/// vez tiene que deserializar en la struct que le corresponde por `type`, y las de pago tienen
+/// que atravesar la conversión completa sin errores.
+///
+/// La evidencia está gitignoreada (`/fiserv_homologacion_logs/`), así que si no está el test se
+/// salta en vez de fallar. Con la evidencia presente cubre las 579 respuestas reales.
+#[test]
+fn the_whole_homologation_evidence_deserializes() {
+    let Some(root) = evidence_root() else {
+        return;
+    };
+    let mut runs: Vec<_> = std::fs::read_dir(&root)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("evidencia.jsonl"))
+        .filter(|path| path.is_file())
+        .collect();
+    runs.sort();
+    if runs.is_empty() {
+        eprintln!("no hay evidencia.jsonl en {root:?}; test salteado");
+        return;
+    }
+
+    let mut checked = 0_usize;
+    for run in &runs {
+        for (line_no, line) in std::fs::read_to_string(run).unwrap().lines().enumerate() {
+            let step: serde_json::Value = serde_json::from_str(line).unwrap();
+            let Some(body) = step.get("response").filter(|body| body.is_object()) else {
+                continue;
+            };
+            let where_ = format!(
+                "{}:{} caso {:?} {} {}",
+                run.display(),
+                line_no + 1,
+                step["case"],
+                step["method"],
+                step["path"]
+            );
+            let http = step["http"]
+                .as_u64()
+                .and_then(|code| u16::try_from(code).ok())
+                .unwrap_or(0);
+            checked += 1;
+            match body["type"].as_str() {
+                // Consulta por orden: sólo el PSync la recibe.
+                Some("orderResponse") => {
+                    let sync: fiservemea::FiservemeaSyncResponse =
+                        serde_json::from_value(body.clone())
+                            .unwrap_or_else(|err| panic!("{where_}: {err}\n{body:#}"));
+                    let response = sync
+                        .into_transaction()
+                        .unwrap_or_else(|err| panic!("{where_}: {err:?}"));
+                    RouterData::try_from(ResponseRouterData {
+                        response,
+                        data: empty_router_data::<()>(),
+                        http_code: http,
+                    })
+                    .unwrap_or_else(|err| panic!("{where_}: {err:?}"));
+                }
+                // Creación de token: struct propia.
+                Some("paymentTokenizationResponse") => {
+                    let _: fiservemea::FiservemeaTokenResponse =
+                        serde_json::from_value(body.clone())
+                            .unwrap_or_else(|err| panic!("{where_}: {err}\n{body:#}"));
+                }
+                // El resto son respuestas de transacción, aprobadas o rechazadas.
+                Some("transactionResponse") | Some("TransactionErrorResponse") => {
+                    let response: fiservemea::FiservemeaPaymentsResponse =
+                        serde_json::from_value(body.clone())
+                            .unwrap_or_else(|err| panic!("{where_}: {err}\n{body:#}"));
+                    RouterData::try_from(ResponseRouterData {
+                        response,
+                        data: empty_router_data::<()>(),
+                        http_code: http,
+                    })
+                    .unwrap_or_else(|err| panic!("{where_}: {err:?}"));
+                    // Y los rechazos, además, por el camino real de los no-2xx.
+                    if !(200..300).contains(&http) {
+                        let _ = error_response(body.clone(), http);
+                    }
+                }
+                // `errorResponse` (400 de validación) o cuerpos sin `type` (el `{}` que devuelve
+                // el ACS, que no es del gateway): sólo los que tengan `error` van por
+                // `build_error_response`.
+                _ => {
+                    if body.get("error").is_some() {
+                        let _ = error_response(body.clone(), http);
+                    }
+                }
+            }
+        }
+    }
+    eprintln!(
+        "respuestas reales barridas: {checked} (en {} corridas)",
+        runs.len()
+    );
+    assert!(
+        checked > 500,
+        "se esperaba barrer las ~579 respuestas de la evidencia, se barrieron {checked}"
+    );
+}
+
+// =============================================================================================
+//  2. Estados y datos de las respuestas aprobadas
+// =============================================================================================
+
+#[test]
+fn approved_sale_is_charged_with_its_transaction_id() {
+    let data = convert(approved_sale(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286258")
+    );
+    let parsed = parsed(&data);
+    assert_eq!(parsed.reference_id.as_deref(), Some("PX-1786053416-01-sale"));
+    assert!(parsed.redirection.is_none());
+    // Sin `paymentToken.value` no hay nada que guardar como mandato: publicar uno vacío haría
+    // que Card on File intentara cobrar contra un token inexistente.
+    assert_eq!(parsed.mandate_id, None);
+    // El gateway de cert NUNCA devuelve `schemeTransactionId` (0 de 579 respuestas), así que la
+    // recurrencia Visa no puede armarse con lo que hoy vuelve del gateway.
+    assert_eq!(parsed.network_txn_id, &None);
+    // Los dos BIN coinciden: no hubo sustitución por Network Token, así que no se afirma una.
+    assert_eq!(parsed.metadata, &None);
+}
+
+#[test]
+fn gateway_token_is_published_as_the_mandate_reference() {
+    // Es lo que permite volver a cobrar la tarjeta guardada: sin esto el Hosted Data ID vive
+    // sólo dentro de la ejecución que lo creó.
+    let data = convert(approved_sale_with_gateway_token(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        parsed(&data).mandate_id.map(String::as_str),
+        Some("CF49734F-986F-4FD1-8040-9A16657E9B3E")
+    );
+}
+
+#[test]
+fn network_token_pairing_travels_in_connector_metadata() {
+    let data = convert(approved_sale_with_network_token(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        parsed(&data).metadata,
+        &Some(json!({
+            "networkTokenPairing": {
+                "networkTokenBin": "432312",
+                "networkTokenLast4": "7867",
+                "fundingCardBin": "462294",
+                "fundingCardLast4": "2366"
+            }
+        }))
+    );
+}
+
+#[test]
+fn frictionless_3ds_code_travels_in_connector_metadata() {
+    let data = convert(frictionless_authenticated(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        parsed(&data).metadata,
+        &Some(json!({ "responseCode3dSecure": "1" }))
+    );
+}
+
+#[test]
+fn a_rejected_authentication_that_the_gateway_still_approved_is_charged() {
+    // Caso real incómodo: el 3DS terminó en "Rejected" (`responseCode3dSecure: "6"`) y aun así
+    // el gateway devolvió APPROVED/CAPTURED con HTTP 200. El estado lo manda el resultado de la
+    // transacción, no el de la autenticación: la plata se cobró.
+    let data = convert(three_ds_rejected_but_approved(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    let metadata = parsed(&data).metadata.clone().expect("debe haber metadata");
+    assert_eq!(metadata["responseCode3dSecure"], "6");
+    // Esta misma respuesta trae sustitución por Network Token (bin 441591 vs 401636): los dos
+    // datos tienen que convivir en el mismo objeto.
+    assert_eq!(metadata["networkTokenPairing"]["fundingCardBin"], "401636");
+}
+
+#[test]
+fn approved_void_is_voided() {
+    let data = convert(approved_void(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Voided);
+    // Ojo: el id que vuelve es el de la transacción VOID, no el de la venta anulada.
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286297")
+    );
+}
+
+// =============================================================================================
+//  3. 3DS: los dos pasos intermedios producen redirect y AuthenticationPending
+// =============================================================================================
+
+#[test]
+fn waiting_with_method_form_is_authentication_pending_with_an_html_redirect() {
+    let data = convert(waiting_with_three_ds_method(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::AuthenticationPending);
+    match parsed(&data).redirection {
+        Some(RedirectForm::Html { html_data }) => {
+            assert!(html_data.contains("mdpayacs/3ds-method"));
+        }
+        other => panic!("se esperaba un redirect HTML, salió {other:?}"),
+    }
+    // Y el id tiene que estar para poder mandar el PATCH de continuación.
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286332")
+    );
+}
+
+#[test]
+fn waiting_with_challenge_params_posts_the_creq_to_the_acs() {
+    let data = convert(waiting_with_challenge_params(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::AuthenticationPending);
+    match parsed(&data).redirection {
+        Some(RedirectForm::Form {
+            endpoint,
+            method,
+            form_fields,
+        }) => {
+            assert!(endpoint.starts_with("https://3ds-acs.test.modirum.com/mdpayacs/creq;token="));
+            assert_eq!(*method, common_utils::request::Method::Post);
+            assert!(form_fields.contains_key("creq"));
+            // El gateway de cert no manda `sessionData`, así que el campo no debe inventarse.
+            assert!(!form_fields.contains_key("threeDSSessionData"));
+        }
+        other => panic!("se esperaba un form al ACS, salió {other:?}"),
+    }
+}
+
+// =============================================================================================
+//  4. PSync
+// =============================================================================================
+
+#[test]
+fn psync_without_transaction_status_still_reads_as_charged() {
+    // Las 12 respuestas de INQUIRY de la evidencia llegan SIN `transactionStatus`. Si el estado
+    // dependiera de ese campo, toda venta cobrada se sincronizaría como Pending para siempre.
+    let data = convert_sync(sync_approved_sale(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286294")
+    );
+}
+
+#[test]
+fn psync_by_order_reads_the_transaction_out_of_the_array() {
+    let data = convert_sync(sync_order_response(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Charged);
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286294"),
+        "el orderResponse no puede perder el ipgTransactionId que trae adentro"
+    );
+}
+
+#[test]
+fn psync_of_an_order_with_two_transactions_keeps_the_primary_one() {
+    // La orden de una anulación trae [SALE, VOID]. Quedarse con la última mapearía el VOID.
+    let data = convert_sync(sync_order_of_a_voided_sale(), 200);
+    assert_eq!(
+        connector_transaction_id(&data).as_deref(),
+        Some("84667286296"),
+        "se debe sincronizar con la transacción primaria (la SALE), no con el VOID"
+    );
+}
+
+#[test]
+fn psync_of_a_declined_sale_fails_with_the_only_reason_the_gateway_left() {
+    // Traído en vivo: el PSync de un rechazo llega con HTTP 200, sin `transactionStatus`, sin
+    // `errorMessage` y con un `processor` que sólo trae `avsResponse`. Todo el motivo está en
+    // `approvalCode`, así que el fallback sobre ese campo es lo único que evita que el rechazo
+    // llegue al comercio sin código ni texto.
+    let data = convert_sync(sync_of_a_declined_sale(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Failure);
+    let error = data
+        .response
+        .as_ref()
+        .expect_err("un rechazo debe salir por Err");
+    assert_eq!(error.code, "-11101");
+    assert_eq!(error.message, "installment not supported");
+    assert_eq!(error.reason.as_deref(), Some("installment not supported"));
+    assert_eq!(error.attempt_status, Some(enums::AttemptStatus::Failure));
+    // El id tiene que sobrevivir al rechazo: sin él no se puede volver a consultar ni conciliar.
+    assert_eq!(
+        error.connector_transaction_id.as_deref(),
+        Some("84667287090")
+    );
+    // El `processor` real no trae `responseCode`/`responseMessage`, así que no se puede inventar
+    // un código de red: los tres campos quedan vacíos.
+    assert_eq!(error.network_decline_code, None);
+    assert_eq!(error.network_advice_code, None);
+    assert_eq!(error.network_error_message, None);
+}
+
+/// FALLA CONOCIDA (documentada, no arreglada acá): el PSync de una venta ANULADA vuelve
+/// `Charged`.
+///
+/// El gateway devuelve `transactionType: SALE` + `transactionResult: APPROVED` y avisa que la
+/// plata se liberó **sólo** en `transactionState: VOIDED`, que `map_status` no mira. Verificado
+/// en vivo el 2026-08-12 contra cert por los dos caminos del PSync (por `ipgTransactionId` y por
+/// `orderId`).
+///
+/// Este test fija el comportamiento ACTUAL para que el arreglo lo rompa a propósito. Lo correcto
+/// sería `Voided`.
+#[test]
+fn psync_of_a_voided_sale_reports_voided_not_charged() {
+    // Verificado en vivo contra certificación: al consultar una venta que después se anuló, el
+    // gateway devuelve el tipo y el estado de la VENTA (`transactionType: SALE`,
+    // `transactionStatus: APPROVED`) pero con `transactionState: VOIDED`. Ignorar ese campo
+    // reportaba el pago como cobrado — plata que el comercio cree haber cobrado y no cobró.
+    let by_transaction = convert_sync(sync_of_a_voided_sale(), 200);
+    assert_eq!(by_transaction.status, enums::AttemptStatus::Voided);
+
+    // Lo mismo por la consulta por orden, que es la otra vía del PSync.
+    let by_order = convert_sync(sync_order_of_a_voided_sale(), 200);
+    assert_eq!(by_order.status, enums::AttemptStatus::Voided);
+}
+
+// =============================================================================================
+//  5. Rechazos que NO pasan por el TryFrom: HTTP 409 / 400 -> build_error_response
+// =============================================================================================
+
+#[test]
+fn declined_3ds_409_keeps_the_gateway_code_and_transaction_id() {
+    let error = error_response(declined_3ds_409(), 409);
+    assert_eq!(error.code, "50716");
+    assert_eq!(error.status_code, 409);
+    assert_eq!(
+        error.connector_transaction_id.as_deref(),
+        Some("84667286319"),
+        "sin el id el rechazo no se puede consultar ni conciliar"
+    );
+    assert_eq!(
+        error.reason.as_deref(),
+        Some("Transaction declined. 3D Secure authentication failed.")
+    );
+    // Este 409 no trae bloque `processor`, así que no hay códigos de red que publicar.
+    assert_eq!(error.network_decline_code, None);
+    assert_eq!(error.network_error_message, None);
+}
+
+/// FALLA CONOCIDA (documentada, no arreglada acá): en el camino de error, el `message` que ve el
+/// comercio es el `responseType` genérico (`GatewayDeclined`) y el motivo real queda sólo en
+/// `reason`. `payment_response.rs` guarda `err.message` en `error_message` del intento, así que
+/// los 107 rechazos 409/400 de la evidencia llegan al comercio etiquetados "GatewayDeclined".
+///
+/// El camino hermano (rechazo con HTTP 2xx, dentro del `TryFrom`) hace lo contrario: pone el
+/// texto real en `message`. Este test fija la asimetría actual.
+#[test]
+fn declined_message_is_the_generic_response_type_bug() {
+    let error = error_response(declined_3ds_409(), 409);
+    assert_eq!(
+        error.message, "GatewayDeclined",
+        "comportamiento actual; el texto útil está en `reason`"
+    );
+
+    // Mismo problema por el 400 de validación, que además no trae `responseType`: ahí el
+    // `message` termina siendo la constante genérica del repo.
+    let error = error_response(invalid_input_400(), 400);
+    assert_eq!(error.code, "INVALID_INPUT");
+    assert_eq!(error.message, hyperswitch_interfaces::consts::NO_ERROR_MESSAGE);
+    // El detalle sí sobrevive, con el campo que el gateway señaló.
+    let reason = error.reason.expect("el detalle del 400 no puede perderse");
+    assert!(reason.contains("softDescriptor"));
+    assert!(reason.contains("Invalid request input"));
+}
+
+/// FALLA CONOCIDA (documentada, no arreglada acá): el `responseCode3dSecure` se descarta en el
+/// camino de error.
+///
+/// `FiservemeaErrorResponse` no declara `secure3dResponse` y `build_error_response` fija
+/// `connector_metadata: None`. Los 409 son el desenlace de 51+19+16 = 86 respuestas reales con
+/// `secure3dResponse`, o sea que justamente en los rechazos de 3DS —donde el código de
+/// autenticación es el dato que explica el rechazo— no queda registrado en ninguna parte. En el
+/// camino 2xx sí se publica (ver `frictionless_3ds_code_travels_in_connector_metadata`).
+#[test]
+fn three_ds_response_code_survives_the_error_path() {
+    // 11 de las 22 filas 3DS del checklist terminan en este camino (HTTP 409), y el
+    // `responseCode3dSecure` es justamente el dato que Fiserv pide informar por caso: si el
+    // conector lo descarta, la evidencia de homologación no se puede armar desde Hyperswitch.
+    for raw in [
+        declined_3ds_409(),
+        declined_3ds_409_with_cardholder_info(),
+        declined_data_only_without_transaction_id(),
+    ] {
+        let esperado = raw["secure3dResponse"]["responseCode3dSecure"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let error = error_response(raw, 409);
+        let metadata = error
+            .connector_metadata
+            .expect("el responseCode3dSecure tiene que llegar al ErrorResponse");
+        assert_eq!(
+            metadata.peek()["responseCode3dSecure"].as_str(),
+            Some(esperado.as_str())
+        );
+    }
+}
+
+/// El `cardholderInfo` que el emisor manda para mostrarle al comprador también se descarta:
+/// `FiservemeaSecure3dResponse` sólo declara `responseCode3dSecure`.
+#[test]
+fn cardholder_info_is_not_surfaced_anywhere_bug() {
+    let raw = declined_3ds_409_with_cardholder_info();
+    let expected = raw["secure3dResponse"]["cardholderInfo"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let error = error_response(raw, 409);
+    let seen = format!("{} {:?}", error.message, error.reason);
+    assert!(
+        !seen.contains(&expected),
+        "comportamiento actual: el texto para el comprador no se publica"
+    );
+}
+
+#[test]
+fn the_issuer_decline_422_publishes_the_iso_code_for_the_retry_engine() {
+    // Es el rechazo más común en producción y el único que trae el `processor` completo. Los
+    // códigos de red son los que gobiernan los reintentos: sin ellos el motor de recovery
+    // reintenta contra un "Do not honour" definitivo.
+    let error = error_response(issuer_decline_422(), 422);
+    assert_eq!(error.status_code, 422);
+    // Ojo: `code` es el código del GATEWAY (50005), no el ISO del emisor (05). El ISO viaja
+    // aparte, en `network_decline_code`.
+    assert_eq!(error.code, "50005");
+    assert_eq!(error.reason.as_deref(), Some("Do not honour"));
+    assert_eq!(error.network_decline_code.as_deref(), Some("05"));
+    assert_eq!(error.network_error_message.as_deref(), Some("Do not honour"));
+    assert_eq!(error.network_advice_code, None);
+    assert_eq!(
+        error.connector_transaction_id.as_deref(),
+        Some("84668174890")
+    );
+    // Misma asimetría que en el 409: el `message` es el `responseType` genérico.
+    assert_eq!(error.message, "EndpointDeclined");
+}
+
+#[test]
+fn psync_of_an_issuer_decline_carries_the_iso_code_as_the_error_code() {
+    // Por el camino 2xx (el PSync) el `processor` viene completo, así que acá sí el código que
+    // ve el comercio es el ISO del emisor y el texto es el del procesador.
+    let data = convert_sync(sync_of_an_issuer_declined_sale(), 200);
+    assert_eq!(data.status, enums::AttemptStatus::Failure);
+    let error = data.response.as_ref().expect_err("debe ser Err");
+    assert_eq!(error.code, "05");
+    assert_eq!(error.message, "Do not honour");
+    assert_eq!(error.network_decline_code.as_deref(), Some("05"));
+    assert_eq!(error.network_error_message.as_deref(), Some("Do not honour"));
+    assert_eq!(
+        error.connector_transaction_id.as_deref(),
+        Some("84668174890")
+    );
+}
+
+#[test]
+fn a_decline_without_a_transaction_id_still_carries_its_reason() {
+    // El Data Only rechazado falla antes de crear la transacción: no hay `ipgTransactionId`.
+    // El conector cae al `orderId` para el PSync (ver `build_sync_url`), pero el `ErrorResponse`
+    // se queda sin id, así que el código y el motivo son lo único que le llega al comercio.
+    let error = error_response(declined_data_only_without_transaction_id(), 409);
+    assert_eq!(error.code, "50655");
+    assert_eq!(error.connector_transaction_id, None);
+    assert_eq!(error.reason.as_deref(), Some("Unable to verify card enrollment"));
+}
+
+#[test]
+fn no_real_decline_arrives_without_a_code_or_a_reason() {
+    // Barrido sobre todas las formas de rechazo capturadas, por los dos caminos: ninguna puede
+    // terminar en el `NO_ERROR_CODE`/`NO_ERROR_MESSAGE` genérico, porque un rechazo sin motivo
+    // es un rechazo que el comercio no puede explicarle a su cliente.
+    for (name, raw, status) in [
+        ("409 3DS", declined_3ds_409(), 409),
+        (
+            "409 3DS con cardholderInfo",
+            declined_3ds_409_with_cardholder_info(),
+            409,
+        ),
+        (
+            "409 Data Only",
+            declined_data_only_without_transaction_id(),
+            409,
+        ),
+        ("422 rechazo del emisor", issuer_decline_422(), 422),
+    ] {
+        let error = error_response(raw, status);
+        assert_ne!(
+            error.code,
+            hyperswitch_interfaces::consts::NO_ERROR_CODE,
+            "{name} llegó sin código"
+        );
+        assert!(
+            error.reason.is_some(),
+            "{name} llegó sin motivo"
+        );
+    }
+
+    // Y el rechazo que llega con HTTP 2xx (el PSync de una venta rechazada), que sale por el
+    // `TryFrom`.
+    let data = convert_sync(sync_of_a_declined_sale(), 200);
+    let error = data.response.as_ref().expect_err("debe ser Err");
+    assert_ne!(error.code, hyperswitch_interfaces::consts::NO_ERROR_CODE);
+    assert_ne!(
+        error.message,
+        hyperswitch_interfaces::consts::NO_ERROR_MESSAGE
+    );
+}
+
+// =============================================================================================
+//  6. Ninguna respuesta aprobada se queda sin id para sincronizar
+// =============================================================================================
+
+#[test]
+fn every_approved_response_carries_an_id_to_sync_with() {
+    for (name, raw) in [
+        ("sale aprobada", approved_sale()),
+        ("sale con token GW", approved_sale_with_gateway_token()),
+        ("sale con network token", approved_sale_with_network_token()),
+        ("3DS frictionless", frictionless_authenticated()),
+        ("3DS rechazado pero aprobado", three_ds_rejected_but_approved()),
+        ("void", approved_void()),
+        ("WAITING con 3DSMethod", waiting_with_three_ds_method()),
+        ("WAITING con desafío", waiting_with_challenge_params()),
+    ] {
+        let data = convert(raw, 200);
+        assert!(
+            connector_transaction_id(&data).is_some(),
+            "{name} quedó sin connector_transaction_id: el pago no se puede sincronizar"
+        );
+    }
+}

--- a/crates/hyperswitch_connectors/src/connectors/fiservemea/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea/transformers.rs
@@ -7,7 +7,7 @@ use common_utils::{
 };
 use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
-    router_data::{ConnectorAuthType, PaymentMethodToken, RouterData},
+    router_data::{ConnectorAuthType, ErrorResponse, PaymentMethodToken, RouterData},
     router_flow_types::{
         payments::{self, SetupMandate},
         refunds::{Execute, RSync},
@@ -15,19 +15,25 @@ use hyperswitch_domain_models::{
     router_request_types::{
         CompleteAuthorizeRedirectResponse, ResponseId, SetupMandateRequestData,
     },
-    router_response_types::{PaymentsResponseData, RedirectForm, RefundsResponseData},
+    router_response_types::{
+        MandateReference, PaymentsResponseData, RedirectForm, RefundsResponseData,
+    },
     types::{
         PaymentsAuthorizeRouterData, PaymentsCancelRouterData, PaymentsCaptureRouterData,
         PaymentsCompleteAuthorizeRouterData, RefundsRouterData, TokenizationRouterData,
     },
 };
-use hyperswitch_interfaces::errors;
+use error_stack::ResultExt;
+use hyperswitch_interfaces::{consts, errors};
 use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{RefundsResponseRouterData, ResponseRouterData},
-    utils::{CardData as _, RouterData as _},
+    utils::{
+        CardData as _, CardIssuer, NetworkTokenData as _,
+        PaymentsAuthorizeRequestData as _, RouterData as _,
+    },
 };
 
 //TODO: Fill the struct with respective fields
@@ -72,7 +78,17 @@ pub struct FiservemeaOrder {
     additional_details: Option<FiservemeaAdditionalDetails>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     soft_descriptor: Option<FiservemeaSoftDescriptor>,
+    /// Criptograma del Network Token, en base64. Sólo aplica al flujo passthrough (§9.2), donde
+    /// el comercio ya tiene su propio token de red: en el flujo integrado el gateway resuelve el
+    /// token por su cuenta y este campo no va. El gateway valida el largo entre 20 y 256
+    /// caracteres (verificado contra cert: `"ZZZZ"` devuelve
+    /// `order.tokenCryptogram: size must be between 20 and 256`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    token_cryptogram: Option<Secret<String>>,
 }
+
+/// Largos que el gateway acepta para `order.tokenCryptogram`.
+const FISERVEMEA_TOKEN_CRYPTOGRAM_LEN: std::ops::RangeInclusive<usize> = 20..=256;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum FiservemeaLegalFramework {
@@ -105,6 +121,16 @@ pub struct FiservemeaMetadataObject {
     pub dynamic_merchant_name: Option<String>,
     /// Opt-in to Mastercard 3DS Data-Only (`messageCategory: "80"`, vendor doc §10.1.6).
     pub three_ds_data_only: Option<bool>,
+    /// Declara que la tarjeta detrás de un token guardado es Mastercard, para poder emitir el
+    /// bloque de Card on File que la guía pide para esa marca. Sólo hace falta cuando se cobra
+    /// con un token de IPG, donde el request no trae la marca.
+    pub card_network_is_mastercard: Option<bool>,
+    /// `authenticationRequest.challengeIndicator` crudo, tal como lo mandó el comercio; se
+    /// valida en `FiservemeaAuthenticationRequest::new` contra `FISERVEMEA_CHALLENGE_INDICATORS`.
+    pub challenge_indicator: Option<String>,
+    /// `authenticationRequest.challengeWindowSize` crudo; se valida contra
+    /// `FISERVEMEA_CHALLENGE_WINDOW_SIZES`.
+    pub challenge_window_size: Option<String>,
 }
 
 /// Looks up `keys` (in order) inside `source` (a JSON object) and returns the first present
@@ -173,11 +199,44 @@ fn extract_dynamic_merchant_name(source: Option<&serde_json::Value>) -> Option<S
 /// Extracts the `three_ds_data_only` opt-in flag (JSON bool or bool-ish string), mirroring
 /// `extract_installment_interest`. `None` when absent/unparseable.
 fn extract_three_ds_data_only(source: Option<&serde_json::Value>) -> Option<bool> {
-    let value = lookup_field(source, &["three_ds_data_only", "threeDsDataOnly"])?;
+    extract_bool_field(source, &["three_ds_data_only", "threeDsDataOnly"])
+}
+
+/// Lee un bool que puede venir como bool JSON o como string bool-ish, igual que el resto de los
+/// extractores de metadata de este archivo.
+fn extract_bool_field(source: Option<&serde_json::Value>, keys: &[&str]) -> Option<bool> {
+    let value = lookup_field(source, keys)?;
     value.as_bool().or_else(|| match value.as_str() {
         Some(s) if s.eq_ignore_ascii_case("true") => Some(true),
         Some(s) if s.eq_ignore_ascii_case("false") => Some(false),
         _ => None,
+    })
+}
+
+/// Extrae el valor crudo de `challengeIndicator`/`challengeWindowSize` de una fuente JSON.
+///
+/// A diferencia del resto de los `extract_*`, acá un valor mal formado NO se descarta: se
+/// devuelve tal cual para que la validación posterior lo rechace. Descartarlo caería al default
+/// `01`/`05`, y en el caso del indicador eso puede ser una autenticación más débil que la que el
+/// comercio pidió (p. ej. un `04` con typo terminaría como "sin preferencia").
+/// Todo lo que sea un entero —el número JSON `3` o el string `"3"`— se normaliza a dos dígitos
+/// (`"03"`), porque la guía escribe los valores con cero a la izquierda y es fácil que un cliente
+/// mande el número pelado.
+/// Un `null` o un string vacío se toman como "no configurado" (y por lo tanto caen al default),
+/// no como valor inválido: es la forma habitual en que un cliente serializa un campo opcional
+/// que no completó.
+fn extract_challenge_field(source: Option<&serde_json::Value>, keys: &[&str]) -> Option<String> {
+    let raw = match lookup_field(source, keys)? {
+        serde_json::Value::Null => return None,
+        serde_json::Value::String(s) => s.trim().to_string(),
+        other => other.to_string(),
+    };
+    if raw.is_empty() {
+        return None;
+    }
+    Some(match raw.parse::<u8>() {
+        Ok(number) => format!("{number:02}"),
+        Err(_) => raw,
     })
 }
 
@@ -204,16 +263,117 @@ impl FiservemeaMetadataObject {
                 .or_else(|| extract_dynamic_merchant_name(frm_metadata)),
             three_ds_data_only: extract_three_ds_data_only(metadata)
                 .or_else(|| extract_three_ds_data_only(frm_metadata)),
+            challenge_indicator: extract_challenge_field(metadata, CHALLENGE_INDICATOR_KEYS)
+                .or_else(|| extract_challenge_field(frm_metadata, CHALLENGE_INDICATOR_KEYS)),
+            challenge_window_size: extract_challenge_field(metadata, CHALLENGE_WINDOW_SIZE_KEYS)
+                .or_else(|| extract_challenge_field(frm_metadata, CHALLENGE_WINDOW_SIZE_KEYS)),
+            card_network_is_mastercard: extract_bool_field(metadata, CARD_NETWORK_MASTERCARD_KEYS)
+                .or_else(|| extract_bool_field(frm_metadata, CARD_NETWORK_MASTERCARD_KEYS)),
         }
     }
 }
 
+const CARD_NETWORK_MASTERCARD_KEYS: &[&str] =
+    &["card_network_is_mastercard", "cardNetworkIsMastercard"];
+const CHALLENGE_INDICATOR_KEYS: &[&str] = &["challenge_indicator", "challengeIndicator"];
+const CHALLENGE_WINDOW_SIZE_KEYS: &[&str] = &["challenge_window_size", "challengeWindowSize"];
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FiservemeaInstallmentOptions {
-    number_of_installments: i32,
+    /// Opcional porque los ejemplos de recurrencia de la guía mandan `installmentOptions` con
+    /// sólo `recurringType`, sin cuotas. Cuando hay cuotas se serializa igual que antes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    number_of_installments: Option<i32>,
     #[serde(rename = "Interest", skip_serializing_if = "Option::is_none", default)]
     interest: Option<bool>,
+    /// `FIRST` en la primera transacción del ciclo recurrente y `REPEAT` en las siguientes
+    /// (guía §11.3.1). Va acá dentro y no a nivel de `order`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recurring_type: Option<FiservemeaRecurringType>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum FiservemeaRecurringType {
+    First,
+    Repeat,
+}
+
+/// Mensajería de credencial almacenada (Card on File), a nivel raíz del request.
+///
+/// Los valores salen de los ejemplos de la guía §11.3.1, y NO son simétricos entre marcas:
+///
+/// - **Visa FIRST**: no lleva `storedCredentials`; alcanza `recurringType: FIRST`.
+/// - **Visa REPEAT**: `sequence: SUBSEQUENT` + `referencedSchemeTransactionId` con el
+///   `schemeTransactionId` que devolvió la transacción original.
+/// - **Mastercard FIRST y REPEAT**: `initiator: MERCHANT` +
+///   `indicatorSubcategory: CREDENTIAL_ON_FILE_FIRST` en los dos casos (el ejemplo de la guía
+///   repite `CREDENTIAL_ON_FILE_FIRST` también en la SUBSEQUENT), y el FIRST agrega además el
+///   bloque de 3DS Data Only.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FiservemeaStoredCredentials {
+    sequence: FiservemeaStoredCredentialSequence,
+    scheduled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    initiator: Option<FiservemeaStoredCredentialInitiator>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    indicator_subcategory: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    referenced_scheme_transaction_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum FiservemeaStoredCredentialSequence {
+    First,
+    Subsequent,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum FiservemeaStoredCredentialInitiator {
+    Cardholder,
+    Merchant,
+}
+
+/// Único valor de `indicatorSubcategory` que usan los ejemplos de la guía.
+const FISERVEMEA_INDICATOR_CREDENTIAL_ON_FILE_FIRST: &str = "CREDENTIAL_ON_FILE_FIRST";
+
+impl FiservemeaStoredCredentials {
+    /// Arma el bloque según marca y posición en el ciclo, siguiendo los ejemplos de la guía.
+    /// Devuelve `None` cuando la guía no manda el bloque (el FIRST de Visa).
+    fn new(
+        is_mastercard: bool,
+        is_first: bool,
+        referenced_scheme_transaction_id: Option<String>,
+    ) -> Option<Self> {
+        let sequence = if is_first {
+            FiservemeaStoredCredentialSequence::First
+        } else {
+            FiservemeaStoredCredentialSequence::Subsequent
+        };
+        if is_mastercard {
+            return Some(Self {
+                sequence,
+                scheduled: false,
+                initiator: Some(FiservemeaStoredCredentialInitiator::Merchant),
+                indicator_subcategory: Some(FISERVEMEA_INDICATOR_CREDENTIAL_ON_FILE_FIRST),
+                referenced_scheme_transaction_id,
+            });
+        }
+        // Visa: el FIRST no lleva el bloque, y el REPEAT lo lleva sólo para transportar el
+        // `referencedSchemeTransactionId`. Sin ese id no hay nada que informar.
+        let referenced = referenced_scheme_transaction_id?;
+        Some(Self {
+            sequence,
+            scheduled: false,
+            initiator: None,
+            indicator_subcategory: None,
+            referenced_scheme_transaction_id: Some(referenced),
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -255,7 +415,11 @@ pub struct FiservemeaExpiryDate {
 pub struct FiservemeaPaymentCard {
     number: cards::CardNumber,
     expiry_date: FiservemeaExpiryDate,
-    security_code: Secret<String>,
+    /// Opcional porque el network token passthrough no lo lleva: la guía dice que ahí "el
+    /// parámetro CardCodeValue no será requerido". En los pagos con tarjeta va siempre, así que
+    /// el request serializado queda igual que antes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    security_code: Option<Secret<String>>,
     // Documented `paymentCard` field (Appendix III / §7.2). Sending the cardholder name aids
     // 3DS success and AVS. Serialized as `cardholderName`; omitted entirely when absent so a
     // request without a holder name stays byte-identical to the previous behavior.
@@ -280,13 +444,204 @@ pub struct FiservemeaPaymentTokenRef {
     token_origin_store_id: Secret<String>,
 }
 
+/// Subclase 3DS 2.1/2.2 del `authenticationRequest`. Acepta `challengeIndicator` y
+/// `challengeWindowSize`, pero NO `messageCategory`.
+const FISERVEMEA_AUTH_TYPE_SECURE3D21: &str = "Secure3D21AuthenticationRequest";
+
+/// Clase base del `authenticationRequest`, la única que declara `messageCategory`
+/// (guía §10.1.6). Es la que exige la modalidad Data Only.
+const FISERVEMEA_AUTH_TYPE_SECURE3D_BASE: &str = "Secure3DAuthenticationRequest";
+
+/// `messageCategory` de la modalidad Mastercard Data Only (guía §10.1.6 y §10.4).
+const FISERVEMEA_MESSAGE_CATEGORY_DATA_ONLY: &str = "80";
+
+/// Valores válidos de `challengeIndicator` (guía §10.1.1, pág. 31). El gateway los valida
+/// contra esta misma lista cerrada.
+const FISERVEMEA_CHALLENGE_INDICATORS: [&str; 9] =
+    ["01", "02", "03", "04", "05", "06", "07", "08", "09"];
+
+/// Marcador con el que el conector distingue, en el retorno del 3DS, cuál de las dos URLs se
+/// golpeó. NO es una atestación de autenticación: es un hecho del servidor sobre qué endpoint
+/// recibió la llamada, y por eso se puede confiar en él para decidir el flujo.
+const THREE_DS_CALLBACK_PARAM: &str = "fiservemea3ds";
+/// La URL que se le da al ACS para que publique la notificación del 3DSMethod. Esa llamada
+/// ocurre DENTRO del iframe oculto, así que su respuesta es invisible y no puede ser la que
+/// continúe la autenticación.
+const THREE_DS_CALLBACK_METHOD: &str = "method";
+/// La URL a la que el wrapper navega la ventana principal cumplida la espera. Es la única visible
+/// para el tarjetahabiente, así que es la que tiene que llevar el PATCH de continuación: su
+/// respuesta es la que trae el desafío.
+const THREE_DS_CALLBACK_TERM: &str = "term";
+
+/// Cuelga el marcador del `complete_authorize_url` sin romper un query string existente.
+fn build_three_ds_callback_url(
+    complete_authorize_url: &str,
+    callback: &str,
+) -> Result<String, error_stack::Report<errors::ConnectorError>> {
+    let mut url = url::Url::parse(complete_authorize_url).change_context(
+        errors::ConnectorError::InvalidDataFormat {
+            field_name: "complete_authorize_url",
+        },
+    )?;
+    url.query_pairs_mut()
+        .append_pair(THREE_DS_CALLBACK_PARAM, callback);
+    Ok(url.into())
+}
+
+/// `true` cuando este CompleteAuthorize es la notificación que el ACS publicó en la
+/// `methodNotificationURL`, o sea la que llega dentro del iframe oculto.
+///
+/// Es la llamada que NO debe continuar la autenticación: si lo hiciera, la respuesta —el form del
+/// desafío, o el resultado final— se renderizaría invisible y el tarjetahabiente nunca volvería al
+/// comercio. La continuación la manda el retorno por la `termURL`, que sí ocurre en la ventana
+/// principal.
+///
+/// Se acepta el marcador tanto en el query string como en el payload JSON, porque el ACS publica
+/// de las dos formas. Sin marcador se responde `false`, que es el comportamiento de antes: sirve
+/// para las transacciones iniciadas antes de este cambio.
+pub(super) fn is_acs_method_notification(
+    redirect_response: &CompleteAuthorizeRedirectResponse,
+) -> bool {
+    if let Some(params) = redirect_response.params.as_ref() {
+        for (key, val) in url::form_urlencoded::parse(params.peek().as_bytes()) {
+            if key.eq_ignore_ascii_case(THREE_DS_CALLBACK_PARAM) {
+                return val.eq_ignore_ascii_case(THREE_DS_CALLBACK_METHOD);
+            }
+        }
+    }
+    if let Some(payload) = redirect_response.payload.as_ref() {
+        if let Some(object) = payload.peek().as_object() {
+            if let Some(value) = object
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(THREE_DS_CALLBACK_PARAM))
+                .and_then(|(_, value)| value.as_str())
+            {
+                return value.eq_ignore_ascii_case(THREE_DS_CALLBACK_METHOD);
+            }
+        }
+    }
+    false
+}
+
+/// Espera mínima antes de continuar la autenticación tras mostrar el `methodForm`. La guía es
+/// explícita: hay que esperar un mínimo de 10 segundos a que el ACS complete su POST y recién
+/// entonces determinar el estado de notificación del método.
+const THREE_DS_METHOD_MIN_WAIT_MS: u32 = 10_000;
+
+/// Escapa un valor para meterlo en un atributo HTML entre comillas dobles (`srcdoc`).
+fn escape_html_attribute(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+/// Escapa un valor para usarlo como literal de string JavaScript entre comillas dobles.
+/// `<` va en su forma unicode para que nada dentro del valor pueda cerrar el `<script>`.
+fn escape_js_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '<' => escaped.push_str("\\u003c"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+/// Envuelve el `methodForm` del gateway en una página que sí puede continuar el flujo.
+///
+/// El `methodForm` que manda Fiserv es un iframe **oculto** más un form cuyo `target` apunta a
+/// ese mismo iframe. Entregado tal cual, todo el 3DS queda encerrado ahí: el desafío se
+/// renderiza invisible y el tarjetahabiente nunca vuelve al comercio. El wrapper lo aloja en un
+/// iframe propio (para que el fingerprint del emisor igual se ejecute) y, cumplida la espera
+/// mínima de la guía, navega la **ventana principal** a la URL de retorno, que es la única
+/// forma de que la respuesta siguiente sea visible.
+///
+/// La guarda `window.self === window.top` es necesaria porque esta misma página puede terminar
+/// cargada dentro de un iframe si el ACS reenvía la notificación: en ese caso no debe navegar
+/// nada, o dispararía un retorno duplicado.
+pub(super) fn build_three_ds_method_wrapper(method_form: &str, return_url: &str) -> String {
+    let srcdoc = escape_html_attribute(method_form);
+    let return_url_js = escape_js_string(return_url);
+    format!(
+        r#"<div style="text-align:center;font-family:Arial,Helvetica,sans-serif;padding:24px;">Verificando su tarjeta, aguarde unos segundos…</div>
+<iframe id="fiservemeaThreeDsMethodFrame" style="visibility:hidden;width:1px;height:1px;border:0;position:absolute;" srcdoc="{srcdoc}"></iframe>
+<script type="text/javascript">
+(function () {{
+  if (window.self !== window.top) {{ return; }}
+  var target = "{return_url_js}";
+  var navigated = false;
+  function continueAuthentication() {{
+    if (navigated) {{ return; }}
+    navigated = true;
+    window.location.replace(target);
+  }}
+  window.setTimeout(continueAuthentication, {THREE_DS_METHOD_MIN_WAIT_MS});
+}})();
+</script>"#
+    )
+}
+
+/// Reemplaza el `methodForm` crudo de la respuesta por la página wrapper.
+///
+/// Se hace acá y no en `to_redirection` porque la URL de retorno sale del
+/// `complete_authorize_url` del request, que la conversión genérica de respuestas no ve.
+pub(super) fn wrap_three_ds_method_redirection(router_data: &mut PaymentsAuthorizeRouterData) {
+    // `Html` sólo lo produce la rama del `methodForm`; el desafío sale como `Form` al ACS y no
+    // necesita wrapper. Sin `complete_authorize_url` se deja la respuesta como está.
+    let Some(url) = router_data.request.complete_authorize_url.clone() else {
+        return;
+    };
+    // La ventana principal vuelve por la termURL, que es la que lleva el PATCH de continuación.
+    let Ok(return_url) = build_three_ds_callback_url(&url, THREE_DS_CALLBACK_TERM) else {
+        return;
+    };
+    if let Ok(PaymentsResponseData::TransactionResponse {
+        ref mut redirection_data,
+        ..
+    }) = router_data.response
+    {
+        if let Some(RedirectForm::Html { html_data }) = redirection_data.as_ref() {
+            **redirection_data = Some(RedirectForm::Html {
+                html_data: build_three_ds_method_wrapper(html_data, &return_url),
+            });
+        }
+    }
+}
+
+/// Valores válidos de `challengeWindowSize` (guía §10.1.1, pág. 31):
+/// 01 = 250x400, 02 = 390x400, 03 = 500x600, 04 = 600x400, 05 = pantalla completa.
+const FISERVEMEA_CHALLENGE_WINDOW_SIZES: [&str; 5] = ["01", "02", "03", "04", "05"];
+
+/// `01` = sin preferencia; es además el valor que el gateway completa por defecto si el campo
+/// no viaja, así que mandarlo explícito no cambia el comportamiento.
+const FISERVEMEA_DEFAULT_CHALLENGE_INDICATOR: &str = "01";
+
+/// `05` = pantalla completa. La opción más angosta (`01`, 250x400) rinde mal en viewports
+/// modernos/móviles, así que el default propio es pantalla completa.
+const FISERVEMEA_DEFAULT_CHALLENGE_WINDOW_SIZE: &str = "05";
+
 /// 3DS native (Fiserv IPG "provider-owned" flow) authentication request object.
 /// Only emitted when the payment is `is_three_ds()`; absent otherwise so the
 /// NoThreeDs request stays byte-identical to the pre-3DS behavior. See vendor doc
 /// §10.1.1 (lines 526-578) and design spec §3.4.
 ///
-/// Mastercard Data-Only (`messageCategory: "80"`, vendor doc §10.1.6) is opt-in via
-/// `metadata.three_ds_data_only`; see `message_category` below.
+/// El `authenticationType` no es decorativo: selecciona la clase Java que IPG usa para
+/// deserializar el objeto, y cada clase acepta un conjunto distinto de campos. Ver
+/// `FiservemeaAuthenticationRequest::new` para la bifurcación 3DS normal / Data Only.
 ///
 /// NOTE: 3DS v1 (`Secure3D10AuthenticationRequest`/`payerAuthenticationResponse`, vendor doc
 /// §10.1.5 v1 variant) is intentionally not implemented — the card schemes have sunset 3DS v1,
@@ -303,11 +658,111 @@ pub struct FiservemeaAuthenticationRequest {
     challenge_indicator: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     challenge_window_size: Option<String>,
-    // Mastercard 3DS Data-Only: `"80"` requests authentication data without a challenge
-    // (vendor doc §10.1.6). Set from `metadata.three_ds_data_only`; omitted otherwise so the
-    // normal 3DS request stays byte-identical.
+    // Mastercard 3DS Data-Only: `"80"` pide los datos de autenticación sin desafío
+    // (guía §10.1.6). Sólo existe en la clase base, nunca en `Secure3D21AuthenticationRequest`.
     #[serde(skip_serializing_if = "Option::is_none")]
     message_category: Option<String>,
+}
+
+/// Valida un valor de `challengeIndicator`/`challengeWindowSize` contra la lista cerrada de la
+/// guía. Delegar la validación al gateway no sirve: ante un valor fuera de rango contesta un 400
+/// con un `error` pelado, sin `code` ni `details`
+/// (`"Error parsing json. Erroneous Field: authenticationRequest.challengeIndicator.
+/// Cause: Unexpected value '99'"`), que el comercio no puede correlacionar con su metadata.
+fn validate_challenge_field(
+    value: &str,
+    allowed: &[&str],
+    field_name: &'static str,
+) -> Result<String, error_stack::Report<errors::ConnectorError>> {
+    if allowed.contains(&value) {
+        Ok(value.to_string())
+    } else {
+        Err(errors::ConnectorError::InvalidDataFormat { field_name }.into())
+    }
+}
+
+impl FiservemeaAuthenticationRequest {
+    /// Arma el `authenticationRequest` según la modalidad pedida por el comercio.
+    ///
+    /// Data Only y 3DS normal no comparten la misma clase de request. `messageCategory` sólo
+    /// existe en la clase base `Secure3DAuthenticationRequest`: emitirlo junto a la subclase
+    /// `Secure3D21AuthenticationRequest` hace que el gateway rechace la transacción entera con
+    /// 400 `INVALID_INPUT` / `"No field named 'messageCategory' exists for class
+    /// Secure3D21AuthenticationRequest"` (verificado contra cert), así que el pago ni siquiera
+    /// llega a autorizarse. Por simetría con el ejemplo de la guía §10.1.6, la rama Data Only
+    /// tampoco manda `challengeIndicator`/`challengeWindowSize`: en Data Only no hay desafío
+    /// que configurar.
+    fn new(
+        term_url: String,
+        method_notification_url: String,
+        meta: &FiservemeaMetadataObject,
+        is_mastercard: bool,
+    ) -> Result<Self, error_stack::Report<errors::ConnectorError>> {
+        let challenge_indicator = meta
+            .challenge_indicator
+            .as_deref()
+            .map(|value| {
+                validate_challenge_field(
+                    value,
+                    &FISERVEMEA_CHALLENGE_INDICATORS,
+                    "metadata.challenge_indicator",
+                )
+            })
+            .transpose()?;
+        // El tamaño de la ventana del desafío no es un parámetro de autenticación: es el
+        // tamaño del iframe. Un valor fuera de rango no degrada nada, así que se cae al default
+        // en vez de tirar el pago abajo — a diferencia del indicador, donde sí importa.
+        let challenge_window_size = meta.challenge_window_size.as_deref().filter(|value| {
+            let valido = FISERVEMEA_CHALLENGE_WINDOW_SIZES.contains(value);
+            if !valido {
+                router_env::logger::warn!(
+                    challenge_window_size = %value,
+                    "fiservemea: challengeWindowSize fuera de rango; se usa el default"
+                );
+            }
+            valido
+        });
+
+        // Data Only existe sólo para Mastercard. Con cualquier otra marca el gateway responde
+        // `50738 "Invalid Message Category"` (verificado contra cert con una Visa), así que si
+        // el comercio deja la bandera puesta como default global, todas sus ventas Visa
+        // fallarían. Se ignora la bandera en vez de fallar: la alternativa correcta para esa
+        // tarjeta es el 3DS normal, que es exactamente lo que hace la rama de abajo.
+        let data_only = meta.three_ds_data_only.unwrap_or(false) && is_mastercard;
+        if meta.three_ds_data_only.unwrap_or(false) && !is_mastercard {
+            router_env::logger::warn!(
+                "fiservemea: three_ds_data_only pedido en una tarjeta que no es Mastercard; \
+                 se ignora y se usa 3DS normal (Data Only es exclusivo de Mastercard)"
+            );
+        }
+
+        if data_only {
+            return Ok(Self {
+                authentication_type: FISERVEMEA_AUTH_TYPE_SECURE3D_BASE.to_string(),
+                term_url,
+                method_notification_url,
+                challenge_indicator: None,
+                challenge_window_size: None,
+                message_category: Some(FISERVEMEA_MESSAGE_CATEGORY_DATA_ONLY.to_string()),
+            });
+        }
+
+        Ok(Self {
+            authentication_type: FISERVEMEA_AUTH_TYPE_SECURE3D21.to_string(),
+            term_url,
+            method_notification_url,
+            challenge_indicator: Some(
+                challenge_indicator
+                    .unwrap_or_else(|| FISERVEMEA_DEFAULT_CHALLENGE_INDICATOR.to_string()),
+            ),
+            challenge_window_size: Some(
+                challenge_window_size
+                    .unwrap_or(FISERVEMEA_DEFAULT_CHALLENGE_WINDOW_SIZE)
+                    .to_string(),
+            ),
+            message_category: None,
+        })
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -321,17 +776,44 @@ pub struct FiservemeaPaymentsRequest {
     payment_method: FiservemeaPaymentMethods,
     #[serde(skip_serializing_if = "Option::is_none")]
     authentication_request: Option<FiservemeaAuthenticationRequest>,
+    /// Mensajería de Card on File. Va a nivel raíz del request, no dentro de `order`
+    /// (guía §11.3.1). `None` en los pagos sueltos, que es el caso por defecto y deja el
+    /// request serializado byte a byte igual que antes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stored_credentials: Option<FiservemeaStoredCredentials>,
 }
 
 /// Whether `capture_method` signals auto-capture (`Automatic`/`SequentialAutomatic`), i.e. the
 /// transaction should be treated as a sale/postauth rather than a pre-auth. Shared by the
 /// Authorize request-type selection and `select_void_request_type` below, which both need the
 /// same auto-capture-vs-manual distinction.
+/// Largo máximo de `merchantTransactionId` en IPG (verificado contra el gateway cert).
+const FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN: usize = 40;
+
+/// Parte el `approvalCode` de IPG, que llega como `<Y|N>:<código>:<texto>`
+/// (por ejemplo `N:-11101:installment not supported` o `N:05:Do not honour`),
+/// en (código, texto). Devuelve `(None, None)` si no tiene esa forma, para no
+/// inventar un código cuando el gateway manda algo distinto.
+fn split_approval_code(approval_code: Option<&str>) -> (Option<String>, Option<String>) {
+    let mut parts = match approval_code {
+        Some(code) => code.splitn(3, ':'),
+        None => return (None, None),
+    };
+    let (_prefix, code, message) = (parts.next(), parts.next(), parts.next());
+    let non_empty = |s: Option<&str>| {
+        s.map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    (non_empty(code), non_empty(message))
+}
+
 fn is_auto_capture(capture_method: Option<enums::CaptureMethod>) -> bool {
-    matches!(
-        capture_method,
-        Some(enums::CaptureMethod::Automatic) | Some(enums::CaptureMethod::SequentialAutomatic)
-    )
+    // `None` significa captura automática en la API de Hyperswitch, igual que en
+    // PaymentsAuthorizeRequestData::is_auto_capture (crates/hyperswitch_connectors/src/utils.rs).
+    // Tratarlo como manual mandaba PaymentCardPreAuthTransaction en pagos que el
+    // comercio pidió automáticos: quedaba la retención sin capturar.
+    !matches!(capture_method, Some(enums::CaptureMethod::Manual))
 }
 
 impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for FiservemeaPaymentsRequest {
@@ -349,11 +831,24 @@ impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for Fiservemea
                 .as_ref()
                 .map(|secret| secret.peek()),
         );
-        let installment_options = fiservemea_meta.installments.and_then(|n| {
-            (n > 1).then_some(FiservemeaInstallmentOptions {
-                number_of_installments: n,
-                interest: fiservemea_meta.installment_interest,
-            })
+        // `installmentOptions` puede existir por cuotas, por recurrencia (`recurringType`), o
+        // por las dos: la guía manda el mismo bloque para ambas cosas.
+        let installments = fiservemea_meta.installments.filter(|n| *n > 1);
+        let recurring_type = if item.router_data.request.is_cit_mandate_payment() {
+            Some(FiservemeaRecurringType::First)
+        } else if item.router_data.request.is_mandate_payment() {
+            Some(FiservemeaRecurringType::Repeat)
+        } else {
+            None
+        };
+        let installment_options = (installments.is_some() || recurring_type.is_some()).then(|| {
+            FiservemeaInstallmentOptions {
+                number_of_installments: installments,
+                // `Interest` sólo tiene sentido con un plan de cuotas: mandarlo suelto en un
+                // recurrente sin cuotas sería un campo sin referente.
+                interest: installments.and(fiservemea_meta.installment_interest),
+                recurring_type,
+            }
         });
         let additional_details =
             fiservemea_meta
@@ -366,23 +861,85 @@ impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for Fiservemea
                 dynamic_merchant_name: Secret::new(name),
             }
         });
-        let order = FiservemeaOrder {
+        let mut order = FiservemeaOrder {
             order_id: item.router_data.connector_request_reference_id.clone(),
             installment_options,
             additional_details,
             soft_descriptor,
+            // Se completa más abajo, sólo en la rama de network token passthrough.
+            token_cryptogram: None,
         };
+        // IPG limita `merchantTransactionId` a 40 caracteres, mientras que
+        // `merchant_order_reference_id` acepta hasta 255 en la API de Hyperswitch:
+        // sin truncar, una referencia larga del comercio hace que el gateway
+        // rechace la transacción entera. `chars()` corta en borde UTF-8.
         let merchant_transaction_id = item
             .router_data
             .request
             .merchant_order_reference_id
             .clone()
-            .unwrap_or(item.router_data.connector_request_reference_id.clone());
+            .unwrap_or(item.router_data.connector_request_reference_id.clone())
+            .chars()
+            .take(FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN)
+            .collect::<String>();
         let transaction_amount = FiservemeaTransactionAmount {
             total: item.amount.clone(),
             currency: item.router_data.request.currency,
         };
         let auto_capture = is_auto_capture(item.router_data.request.capture_method);
+
+        // Señales de Card on File, compartidas por la rama del token y la de tarjeta. La primera
+        // del ciclo es la que trae la aceptación del titular y pide guardar la credencial; las
+        // siguientes llegan con el `schemeTransactionId` de la original, que Hyperswitch persiste
+        // como network transaction id y que Visa exige devolver en
+        // `referencedSchemeTransactionId` (guía §11.3.1.1.b).
+        let is_first_cof = item.router_data.request.is_cit_mandate_payment();
+        let referenced_scheme_transaction_id = item
+            .router_data
+            .request
+            .get_optional_network_transaction_id();
+        // La marca decide la forma del bloque de Card on File, y no es simétrica entre marcas
+        // (ver `FiservemeaStoredCredentials`).
+        //
+        // LÍMITE CONOCIDO: cuando se cobra con un token de IPG ya guardado, el request no trae
+        // ni el PAN ni la marca — `payment_method_data` no es `Card` —, así que no se puede
+        // resolver desde acá. En ese caso se cae a la forma de Visa, que es la mínima que la
+        // guía documenta, y se avisa por log. Para el REPEAT de Mastercard la guía pide además
+        // `initiator: MERCHANT` e `indicatorSubcategory`, que en ese camino no se pueden emitir:
+        // el comercio lo puede forzar declarando la marca en la metadata.
+        let brand_is_mastercard = match &item.router_data.request.payment_method_data {
+            PaymentMethodData::Card(card) => {
+                matches!(card.get_card_issuer(), Ok(CardIssuer::Master))
+            }
+            // El network token sí declara la marca.
+            PaymentMethodData::NetworkToken(token) => {
+                matches!(token.card_network, Some(common_enums::CardNetwork::Mastercard))
+                    || matches!(token.get_card_issuer(), Ok(CardIssuer::Master))
+            }
+            _ => fiservemea_meta.card_network_is_mastercard.unwrap_or(false),
+        };
+        if (is_first_cof || referenced_scheme_transaction_id.is_some())
+            && !brand_is_mastercard
+            && !matches!(
+                item.router_data.request.payment_method_data,
+                PaymentMethodData::Card(_) | PaymentMethodData::NetworkToken(_)
+            )
+        {
+            router_env::logger::warn!(
+                "fiservemea: Card on File sin marca resoluble (se cobra con un token guardado); \
+                 se usa la forma de storedCredentials de Visa. Si la tarjeta es Mastercard, \
+                 declararlo en metadata.card_network_is_mastercard"
+            );
+        }
+        let stored_credentials = if is_first_cof || referenced_scheme_transaction_id.is_some() {
+            FiservemeaStoredCredentials::new(
+                brand_is_mastercard,
+                is_first_cof,
+                referenced_scheme_transaction_id.clone(),
+            )
+        } else {
+            None
+        };
 
         // Card-on-File: pay with a previously created IPG gateway token (vendor doc §9.1.4.2).
         // Hyperswitch runs the PaymentMethodToken flow first and hands the token back here.
@@ -414,18 +971,26 @@ impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for Fiservemea
                     token_origin_store_id: auth.store_id,
                 }),
                 authentication_request: None,
+                // Es el caso central de Card on File: los ejemplos de recurrencia de la guía
+                // usan justamente `PaymentTokenSaleTransaction` con un `paymentToken`.
+                stored_credentials,
             });
         }
 
         match item.router_data.request.payment_method_data.clone() {
             PaymentMethodData::Card(req_card) => {
+                // Se resuelve la marca ANTES de construir `card`, porque ahí `req_card` queda
+                // parcialmente movido. Data Only es exclusivo de Mastercard; un BIN que no se
+                // reconoce se trata como "no Mastercard", que es el lado seguro: se usa 3DS
+                // normal en vez de pedir una modalidad que el gateway rechazaría con 50738.
+                let is_mastercard = matches!(req_card.get_card_issuer(), Ok(CardIssuer::Master));
                 let card = FiservemeaPaymentCard {
                     number: req_card.card_number.clone(),
                     expiry_date: FiservemeaExpiryDate {
                         month: req_card.card_exp_month.clone(),
                         year: req_card.get_card_expiry_year_2_digit()?,
                     },
-                    security_code: req_card.card_cvc,
+                    security_code: Some(req_card.card_cvc),
                     cardholder_name: req_card.card_holder_name.clone(),
                 };
                 let request_type = if auto_capture {
@@ -446,22 +1011,15 @@ impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for Fiservemea
                         .ok_or(errors::ConnectorError::MissingRequiredField {
                             field_name: "complete_authorize_url",
                         })?;
-                    Some(FiservemeaAuthenticationRequest {
-                        authentication_type: "Secure3D21AuthenticationRequest".to_string(),
-                        term_url: return_url.clone(),
-                        method_notification_url: return_url,
-                        // `01` = no preference (vendor doc §10.1.1, line ~536).
-                        challenge_indicator: Some("01".to_string()),
-                        // `05` = full screen (vendor doc §10.1.1, line ~552). The narrowest
-                        // option `01` (250x400) is a poor default on modern/mobile viewports, so
-                        // request full screen for a better challenge UX.
-                        challenge_window_size: Some("05".to_string()),
-                        // Mastercard Data-Only (`"80"`) when opted-in via metadata; else omitted.
-                        message_category: fiservemea_meta
-                            .three_ds_data_only
-                            .unwrap_or(false)
-                            .then(|| "80".to_string()),
-                    })
+                    // Las dos URLs tienen que ser distinguibles: la notificación del ACS llega
+                    // dentro del iframe oculto y no puede continuar la autenticación; el retorno
+                    // del navegador por la termURL sí.
+                    Some(FiservemeaAuthenticationRequest::new(
+                        build_three_ds_callback_url(&return_url, THREE_DS_CALLBACK_TERM)?,
+                        build_three_ds_callback_url(&return_url, THREE_DS_CALLBACK_METHOD)?,
+                        &fiservemea_meta,
+                        is_mastercard,
+                    )?)
                 } else {
                     None
                 };
@@ -474,6 +1032,82 @@ impl TryFrom<&FiservemeaRouterData<&PaymentsAuthorizeRouterData>> for Fiservemea
                     order,
                     payment_method: FiservemeaPaymentMethods::PaymentCard(card),
                     authentication_request,
+                    stored_credentials,
+                })
+            }
+            // Network Token passthrough (§9.2): el comercio ya tiene su token de red (propio o de
+            // un TSP) y Hyperswitch lo entrega acá. El token viaja como `paymentCard.number`,
+            // con su propio vencimiento y SIN CVV — la guía dice textual que "el parámetro
+            // CardCodeValue no será requerido" —, y el criptograma va en `order.tokenCryptogram`.
+            //
+            // No confundir con el flujo MTRG integrado (OnTheGo/Asíncrono), donde se manda el PAN
+            // real con CVV y es Fiserv quien le pide el token a la marca: ése entra por la rama
+            // `PaymentMethodData::Card` de arriba y no lleva criptograma.
+            PaymentMethodData::NetworkToken(token_data) => {
+                // El 3DS sobre un network token se resuelve fuera del conector. Si el comercio
+                // pidió 3DS y acá lo ignoráramos, la venta saldría sin autenticar sin que nadie
+                // se enterase: es una degradación silenciosa de SCA, así que falla cerrado.
+                if item.router_data.is_three_ds() {
+                    return Err(errors::ConnectorError::NotImplemented(
+                        "3DS with a network token for fiservemea".to_string(),
+                    )
+                    .into());
+                }
+
+                // El criptograma es obligatorio en la primera del ciclo, pero la guía dice
+                // textual que "no hará falta enviar el criptograma en las transacciones de tipo
+                // REPEAT" (§11.2). Exigirlo siempre rompería justamente el REPEAT documentado.
+                let cryptogram = token_data.get_cryptogram();
+                let es_repeat = referenced_scheme_transaction_id.is_some() || !is_first_cof;
+                match cryptogram {
+                    Some(cryptogram) => {
+                        // Falla cerrado antes de pegarle al gateway: un criptograma fuera de
+                        // rango devuelve un 400 opaco que no se puede atribuir al campo. El
+                        // largo se mide en caracteres, que es la unidad del mensaje del gateway.
+                        if !FISERVEMEA_TOKEN_CRYPTOGRAM_LEN
+                            .contains(&cryptogram.peek().chars().count())
+                        {
+                            return Err(errors::ConnectorError::InvalidDataFormat {
+                                field_name: "payment_method_data.network_token.token_cryptogram",
+                            }
+                            .into());
+                        }
+                        order.token_cryptogram = Some(cryptogram);
+                    }
+                    None if es_repeat => {}
+                    None => {
+                        return Err(errors::ConnectorError::MissingRequiredField {
+                            field_name: "payment_method_data.network_token.token_cryptogram",
+                        }
+                        .into())
+                    }
+                }
+
+                let card = FiservemeaPaymentCard {
+                    number: token_data.get_network_token(),
+                    expiry_date: FiservemeaExpiryDate {
+                        month: token_data.get_network_token_expiry_month(),
+                        year: token_data.get_token_expiry_year_2_digit()?,
+                    },
+                    // Sin CVV: el token de red no lo lleva.
+                    security_code: None,
+                    cardholder_name: None,
+                };
+                let request_type = if auto_capture {
+                    FiservemeaRequestType::PaymentCardSaleTransaction
+                } else {
+                    FiservemeaRequestType::PaymentCardPreAuthTransaction
+                };
+                Ok(Self {
+                    request_type,
+                    store_id: auth.store_id,
+                    merchant_transaction_id,
+                    transaction_amount,
+                    order,
+                    payment_method: FiservemeaPaymentMethods::PaymentCard(card),
+                    // Ya se verificó arriba que no se pidió 3DS.
+                    authentication_request: None,
+                    stored_credentials,
                 })
             }
             _ => Err(errors::ConnectorError::NotImplemented(
@@ -503,13 +1137,23 @@ impl TryFrom<&RouterData<SetupMandate, SetupMandateRequestData, PaymentsResponse
                         month: req_card.card_exp_month.clone(),
                         year: req_card.get_card_expiry_year_2_digit()?,
                     },
-                    security_code: req_card.card_cvc,
+                    security_code: Some(req_card.card_cvc),
                     cardholder_name: req_card.card_holder_name.clone(),
                 };
                 Ok(Self {
                     request_type: FiservemeaRequestType::PaymentCardSaleTransaction,
                     store_id: auth.store_id,
-                    merchant_transaction_id: item.connector_request_reference_id.clone(),
+                    // Mismo recorte que en Authorize: IPG rechaza con 400 INVALID_INPUT un
+                    // `merchantTransactionId` de más de 40 caracteres (verificado contra el
+                    // gateway cert: 40 pasa, 41 falla). El `connector_request_reference_id` es
+                    // el `attempt_id`, o sea `{payment_id}_{n}`, y el `payment_id` que manda el
+                    // comercio admite hasta 64 caracteres: sin recortar, un Zero Auth con una
+                    // referencia larga se caía entero.
+                    merchant_transaction_id: item
+                        .connector_request_reference_id
+                        .chars()
+                        .take(FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN)
+                        .collect(),
                     // Zero amount: the issuer validates the card without a real charge.
                     transaction_amount: FiservemeaTransactionAmount {
                         total: StringMajorUnit::zero(),
@@ -520,9 +1164,12 @@ impl TryFrom<&RouterData<SetupMandate, SetupMandateRequestData, PaymentsResponse
                         installment_options: None,
                         additional_details: None,
                         soft_descriptor: None,
+                        token_cryptogram: None,
                     },
                     payment_method: FiservemeaPaymentMethods::PaymentCard(card),
                     authentication_request: None,
+                    // El Zero Auth valida la tarjeta, no abre un ciclo recurrente.
+                    stored_credentials: None,
                 })
             }
             _ => Err(errors::ConnectorError::NotImplemented(
@@ -568,7 +1215,7 @@ impl TryFrom<&TokenizationRouterData> for FiservemeaCreateTokenRequest {
                         month: req_card.card_exp_month.clone(),
                         year: req_card.get_card_expiry_year_2_digit()?,
                     },
-                    security_code: req_card.card_cvc,
+                    security_code: Some(req_card.card_cvc),
                     cardholder_name: req_card.card_holder_name.clone(),
                 },
                 create_token: FiservemeaCreateToken {
@@ -798,6 +1445,12 @@ impl TryFrom<&ConnectorAuthType> for FiservemeaAuthType {
 }
 
 // PaymentsResponse
+// Todos los enums de respuesta llevan una variante `Unknown` con `#[serde(other)]`.
+// Sin ella, la deserialización es todo-o-nada: un valor nuevo en CUALQUIERA de estos
+// campos rompe el parseo de la respuesta entera, y como el gateway aprueba con HTTP 2xx,
+// una venta cobrada termina reportada como error de conector (plata cobrada que
+// Hyperswitch no registra). El descarte convierte "no conozco este valor" en un dato
+// más, que después `map_status`/`map_refund_status` resuelven de forma conservadora.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ResponseType {
     BadRequest,
@@ -809,6 +1462,8 @@ pub enum ResponseType {
     ServerError,
     EndpointCommunicationError,
     UnsupportedMediaType,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -823,6 +1478,8 @@ pub enum FiservemeaTransactionType {
     Postauth,
     PayerAuth,
     Disbursement,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -833,9 +1490,11 @@ pub enum FiservemeaTransactionOrigin {
     Mail,
     Phone,
     Retail,
+    #[serde(other)]
+    Unknown,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FiservemeaPaymentStatus {
     Approved,
@@ -844,9 +1503,11 @@ pub enum FiservemeaPaymentStatus {
     ValidationFailed,
     ProcessingFailed,
     Declined,
+    #[serde(other)]
+    Unknown,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FiservemeaPaymentResult {
     Approved,
@@ -855,6 +1516,8 @@ pub enum FiservemeaPaymentResult {
     Waiting,
     Partial,
     Fraud,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -864,6 +1527,65 @@ pub struct FiservemeaPaymentCardResponse {
     bin: Option<String>,
     last4: Option<String>,
     brand: Option<String>,
+    /// BIN y últimos 4 de la tarjeta que FONDEA la transacción, o sea el PAN real. Cuando el
+    /// gateway procesa con Network Token, `bin`/`last4` de arriba son los del TOKEN y estos los
+    /// del PAN. El manual de Network Token lo pide explícitamente: "es necesario que en cada
+    /// transacción aprobada se realice un emparejamiento entre el Network Token y BIN + últimos
+    /// 4 dígitos de la tarjeta original, para poder identificar qué transacción se realizó con
+    /// cada tarjeta", porque en un desconocimiento o una conciliación lo que vuelve es el token.
+    funding_card_number: Option<FiservemeaFundingCardNumber>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiservemeaFundingCardNumber {
+    bin: Option<String>,
+    last4: Option<String>,
+}
+
+/// Emparejamiento Network Token ↔ PAN de una transacción aprobada, tal como lo exige el manual
+/// de Network Token para poder conciliar y atender desconocimientos.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FiservemeaNetworkTokenPairing {
+    /// BIN y últimos 4 del Network Token con el que se procesó.
+    network_token_bin: String,
+    network_token_last4: String,
+    /// BIN y últimos 4 del PAN real que fondea.
+    funding_card_bin: String,
+    funding_card_last4: String,
+}
+
+impl FiservemeaPaymentMethodDetails {
+    /// Devuelve el emparejamiento **sólo** cuando el gateway efectivamente sustituyó por un
+    /// Network Token, o sea cuando el BIN procesado difiere del BIN que fondea.
+    ///
+    /// La comparación es necesaria: IPG manda `fundingCardNumber` también en ventas sin token
+    /// (verificado contra cert), y ahí los dos BIN son el mismo. Emitir el emparejamiento en ese
+    /// caso escribiría un dato afirmativo y falso — diría que hubo tokenización de marca donde
+    /// no hubo — en un campo que después se usa para conciliar.
+    pub(crate) fn network_token_pairing(&self) -> Option<FiservemeaNetworkTokenPairing> {
+        let card = self.payment_card.as_ref()?;
+        let funding = card.funding_card_number.as_ref()?;
+        let (token_bin, funding_bin) = (card.bin.as_ref()?, funding.bin.as_ref()?);
+        if token_bin == funding_bin {
+            return None;
+        }
+        Some(FiservemeaNetworkTokenPairing {
+            network_token_bin: token_bin.clone(),
+            network_token_last4: card.last4.clone()?,
+            funding_card_bin: funding_bin.clone(),
+            funding_card_last4: funding.last4.clone()?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiservemeaResponsePaymentToken {
+    value: Option<Secret<String>>,
+    reusable: Option<bool>,
+    network_token_provision_status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -907,57 +1629,166 @@ pub struct Processor {
     response_message: Option<String>,
     avs_response: Option<AvsResponse>,
     security_code_response: Option<String>,
+    /// Código que devuelve la marca (Visa/Mastercard), distinto del `responseCode` ISO del
+    /// emisor. Fiserv lo publica en REST como `processor.associationResponseCode`
+    /// (`ipgapi:ProcessorAssociationResponseCode` en la API SOAP); es el campo con el que las
+    /// marcas categorizan los rechazos para su política de reintentos.
+    association_response_code: Option<String>,
+    /// Merchant Advice Code de Mastercard (tabla 55). Fiserv sólo lo manda si el comercio pidió
+    /// `order.installmentOptions.merchantAdviceCodeSupported = TRUE` en un pago recurrente
+    /// rechazado (guía, pág. 79). Reintentar contra un MAC que dice "no reintentes" es lo que
+    /// dispara la penalidad de USD 0,50 por transacción del mandato de Mastercard.
+    merchant_advice_code_indicator: Option<String>,
+}
+
+/// Los tres códigos de red que `ErrorResponse` expone para que el motor de reintentos
+/// (revenue recovery) decida si vale la pena reintentar y con qué espera.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct FiservemeaNetworkCodes {
+    pub decline_code: Option<String>,
+    pub advice_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl FiservemeaNetworkCodes {
+    /// Traduce el bloque `processor` de IPG a la convención que ya usan otros conectores del
+    /// repo: el MAC va en `network_advice_code` (igual que `merchantAdvice.codeRaw` en
+    /// cybersource o `merchantAdviceCode` en adyen) y el código de red en
+    /// `network_decline_code`.
+    ///
+    /// Para el código de rechazo se prefiere `associationResponseCode` porque es el que emite la
+    /// marca, y se cae a `responseCode` cuando IPG no lo manda —hoy el gateway de certificación
+    /// nunca lo manda, y sin el fallback el motor de reintentos se quedaría sin ningún código,
+    /// que es exactamente lo que hacen cybersource/bankofamerica/barclaycard mapeando
+    /// `processorInformation.responseCode`. No se cae al `approvalCode`: ese código
+    /// (`N:-11101:...`) es del gateway, no de la red, y mezclarlos haría que el motor de
+    /// reintentos clasifique un error de configuración como si fuera un rechazo del emisor.
+    ///
+    /// `network_error_message` lleva el texto crudo del procesador (`responseMessage`) sin
+    /// fallbacks: si el texto que se muestra vino de `errorMessage` o del `approvalCode`, no es
+    /// de la red y no corresponde publicarlo como tal.
+    pub(crate) fn from_processor(processor: Option<&Processor>) -> Self {
+        Self {
+            // Se usa `responseCode`, que es el único que vimos llevando códigos ISO reales
+            // (01, 05, 51…). NO se prefiere `associationResponseCode`: no aparece ni una vez
+            // en las respuestas del gateway de certificación, y el único ejemplo publicado que
+            // lo trae lo muestra como `"XX"` en una transacción aprobada. Preferirlo sobre un
+            // valor verificado publicaría eso como código de rechazo de red y degradaría la
+            // clasificación de reintentos por debajo de lo que hace hoy.
+            decline_code: processor.and_then(|p| p.response_code.clone()),
+            advice_code: processor.and_then(|p| p.merchant_advice_code_indicator.clone()),
+            error_message: processor.and_then(|p| p.response_message.clone()),
+        }
+    }
+}
+
+/// Estado con el que se resuelve todo dato que el gateway mandó pero el conector no sabe
+/// interpretar (valor nuevo en un enum, o campo ausente).
+///
+/// `Pending` es el único que no miente en ninguna de las dos direcciones peligrosas: no da la
+/// plata por cobrada (nadie despacha mercadería contra un valor que no entendemos) ni la da por
+/// perdida marcando `Failure` sobre una transacción que el gateway pudo haber aprobado y
+/// cobrado. Además deja el intento vivo para que el PSync lo resuelva, mientras que un
+/// `Failure` es terminal y dejaría el cobro huérfano.
+const UNKNOWN_ATTEMPT_STATUS: common_enums::AttemptStatus = common_enums::AttemptStatus::Pending;
+
+/// Estados terminales de `transactionState` que contradicen al `transactionType`, y con qué
+/// hay que quedarse.
+///
+/// Es imprescindible mirar este campo en el PSync: al consultar una venta que después se anuló, el
+/// gateway responde `transactionType: SALE` + `transactionStatus: APPROVED` + `transactionState:
+/// VOIDED` (verificado en vivo contra certificación: venta 1000.00 ARS aprobada con state CAPTURED,
+/// anulada, y la consulta posterior de ESA venta devuelve state VOIDED). Mirando sólo el tipo, un
+/// pago anulado se reporta como cobrado — plata que el comercio cree haber cobrado y no cobró.
+fn map_transaction_state(state: Option<&str>) -> Option<common_enums::AttemptStatus> {
+    match state?.to_ascii_uppercase().as_str() {
+        "VOIDED" => Some(common_enums::AttemptStatus::Voided),
+        "DECLINED" => Some(common_enums::AttemptStatus::Failure),
+        // CAPTURED y WAITING no agregan nada sobre el tipo, y un valor desconocido no debe
+        // pisar la clasificación que sí se conoce.
+        _ => None,
+    }
+}
+
+/// Traduce un resultado aprobado según el tipo de transacción que lo produjo.
+///
+/// `transaction_state` manda cuando es terminal y contradice al tipo (ver `map_transaction_state`).
+fn map_approved_status(
+    transaction_type: Option<&FiservemeaTransactionType>,
+    transaction_state: Option<&str>,
+) -> common_enums::AttemptStatus {
+    if let Some(status) = map_transaction_state(transaction_state) {
+        return status;
+    }
+    match transaction_type {
+        Some(FiservemeaTransactionType::Preauth) => common_enums::AttemptStatus::Authorized,
+        Some(FiservemeaTransactionType::Void) => common_enums::AttemptStatus::Voided,
+        Some(FiservemeaTransactionType::Sale | FiservemeaTransactionType::Postauth) => {
+            common_enums::AttemptStatus::Charged
+        }
+        Some(
+            FiservemeaTransactionType::Credit
+            | FiservemeaTransactionType::ForcedTicket
+            | FiservemeaTransactionType::Return
+            | FiservemeaTransactionType::PayerAuth
+            | FiservemeaTransactionType::Disbursement,
+        ) => common_enums::AttemptStatus::Failure,
+        // Sin un `transactionType` conocido no se puede distinguir entre autorizado,
+        // capturado y anulado: los tres son "aprobado" y significan cosas distintas para el
+        // dinero. Se difiere al PSync en vez de elegir uno al azar.
+        Some(FiservemeaTransactionType::Unknown) | None => UNKNOWN_ATTEMPT_STATUS,
+    }
 }
 
 fn map_status(
     fiservemea_status: Option<FiservemeaPaymentStatus>,
     fiservemea_result: Option<FiservemeaPaymentResult>,
-    transaction_type: FiservemeaTransactionType,
+    transaction_type: Option<FiservemeaTransactionType>,
+    transaction_state: Option<&str>,
 ) -> common_enums::AttemptStatus {
-    match fiservemea_status {
-        Some(status) => match status {
-            FiservemeaPaymentStatus::Approved => match transaction_type {
-                FiservemeaTransactionType::Preauth => common_enums::AttemptStatus::Authorized,
-                FiservemeaTransactionType::Void => common_enums::AttemptStatus::Voided,
-                FiservemeaTransactionType::Sale | FiservemeaTransactionType::Postauth => {
-                    common_enums::AttemptStatus::Charged
-                }
-                FiservemeaTransactionType::Credit
-                | FiservemeaTransactionType::ForcedTicket
-                | FiservemeaTransactionType::Return
-                | FiservemeaTransactionType::PayerAuth
-                | FiservemeaTransactionType::Disbursement => common_enums::AttemptStatus::Failure,
-            },
-            FiservemeaPaymentStatus::Waiting => common_enums::AttemptStatus::Pending,
-            FiservemeaPaymentStatus::Partial => common_enums::AttemptStatus::PartialCharged,
+    // `transactionStatus` está deprecado pero sigue llegando; se lo consulta primero sólo
+    // cuando trae un valor que conocemos. Un valor no contemplado ahí no debe tapar al
+    // `transactionResult`, que es el campo vigente y suele venir en la misma respuesta.
+    let from_status = match fiservemea_status {
+        Some(FiservemeaPaymentStatus::Approved) => {
+            Some(map_approved_status(transaction_type.as_ref(), transaction_state))
+        }
+        Some(FiservemeaPaymentStatus::Waiting) => Some(common_enums::AttemptStatus::Pending),
+        Some(FiservemeaPaymentStatus::Partial) => Some(common_enums::AttemptStatus::PartialCharged),
+        Some(
             FiservemeaPaymentStatus::ValidationFailed
             | FiservemeaPaymentStatus::ProcessingFailed
-            | FiservemeaPaymentStatus::Declined => common_enums::AttemptStatus::Failure,
-        },
-        None => match fiservemea_result {
-            Some(result) => match result {
-                FiservemeaPaymentResult::Approved => match transaction_type {
-                    FiservemeaTransactionType::Preauth => common_enums::AttemptStatus::Authorized,
-                    FiservemeaTransactionType::Void => common_enums::AttemptStatus::Voided,
-                    FiservemeaTransactionType::Sale | FiservemeaTransactionType::Postauth => {
-                        common_enums::AttemptStatus::Charged
-                    }
-                    FiservemeaTransactionType::Credit
-                    | FiservemeaTransactionType::ForcedTicket
-                    | FiservemeaTransactionType::Return
-                    | FiservemeaTransactionType::PayerAuth
-                    | FiservemeaTransactionType::Disbursement => {
-                        common_enums::AttemptStatus::Failure
-                    }
-                },
-                FiservemeaPaymentResult::Waiting => common_enums::AttemptStatus::Pending,
-                FiservemeaPaymentResult::Partial => common_enums::AttemptStatus::PartialCharged,
-                FiservemeaPaymentResult::Declined
-                | FiservemeaPaymentResult::Failed
-                | FiservemeaPaymentResult::Fraud => common_enums::AttemptStatus::Failure,
-            },
-            None => common_enums::AttemptStatus::Pending,
-        },
+            | FiservemeaPaymentStatus::Declined,
+        ) => Some(common_enums::AttemptStatus::Failure),
+        Some(FiservemeaPaymentStatus::Unknown) | None => None,
+    };
+    if let Some(status) = from_status {
+        return status;
+    }
+
+    match fiservemea_result {
+        Some(FiservemeaPaymentResult::Approved) => {
+            map_approved_status(transaction_type.as_ref(), transaction_state)
+        }
+        Some(FiservemeaPaymentResult::Waiting) => common_enums::AttemptStatus::Pending,
+        Some(FiservemeaPaymentResult::Partial) => common_enums::AttemptStatus::PartialCharged,
+        Some(
+            FiservemeaPaymentResult::Declined
+            | FiservemeaPaymentResult::Failed
+            | FiservemeaPaymentResult::Fraud,
+        ) => common_enums::AttemptStatus::Failure,
+        Some(FiservemeaPaymentResult::Unknown) | None => {
+            // Sin este aviso el descarte es mudo: el intento queda en Pending para siempre y
+            // no queda rastro de que el gateway mandó algo que no conocemos. `#[serde(other)]`
+            // ya perdió el string original, así que se registra al menos qué combinación llegó.
+            router_env::logger::warn!(
+                transaction_status = ?fiservemea_status,
+                transaction_result = ?fiservemea_result,
+                transaction_type = ?transaction_type,
+                "fiservemea: estado de transacción no contemplado; se difiere al PSync"
+            );
+            UNKNOWN_ATTEMPT_STATUS
+        }
     }
 }
 
@@ -1020,14 +1851,23 @@ impl FiservemeaAuthenticationResponse {
     /// - `secure3dMethod.methodForm` (§10.1.2) => hidden-iframe HTML for device fingerprinting.
     /// - `params.acsURL` (§10.1.5) => self-posting form to the ACS challenge page. Field names
     ///   `creq`/`threeDSSessionData` are exactly what the ACS expects (vendor doc lines 742-753).
-    fn to_redirection(&self) -> Option<RedirectForm> {
+    ///
+    /// El `methodForm` no se entrega crudo: va dentro de la página de
+    /// `build_three_ds_method_wrapper`, que es la que puede navegar la ventana principal para
+    /// que el paso siguiente sea visible. `return_url` es el `complete_authorize_url`; sin él
+    /// no se puede armar el wrapper y se devuelve el form crudo, que es el comportamiento
+    /// anterior (peor, pero no una regresión).
+    fn to_redirection(&self, return_url: Option<&str>) -> Option<RedirectForm> {
         if let Some(method_form) = self
             .secure3d_method
             .as_ref()
             .and_then(|method| method.method_form.clone())
         {
             return Some(RedirectForm::Html {
-                html_data: method_form,
+                html_data: match return_url {
+                    Some(url) => build_three_ds_method_wrapper(&method_form, url),
+                    None => method_form,
+                },
             });
         }
 
@@ -1057,6 +1897,33 @@ impl FiservemeaAuthenticationResponse {
 #[serde(rename_all = "camelCase")]
 pub struct FiservemeaSecure3dResponse {
     response_code3d_secure: Option<String>,
+    /// Mensaje que el emisor manda para mostrarle al comprador cuando rechaza la autenticación
+    /// (por ejemplo "Your card has not been configured to support EMV 3-D Secure").
+    cardholder_info: Option<String>,
+    /// Motivo numérico del `transStatus`. No está documentado en el material de Fiserv, así que
+    /// se publica tal cual, sin interpretarlo.
+    transaction_status_reason: Option<String>,
+}
+
+impl FiservemeaSecure3dResponse {
+    /// Empaqueta el resultado de la autenticación para publicarlo. Es lo que el checklist de
+    /// homologación pide informar por caso.
+    pub(crate) fn to_metadata(&self) -> Option<serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        if let Some(code) = self.response_code3d_secure.as_ref() {
+            map.insert("responseCode3dSecure".to_string(), serde_json::json!(code));
+        }
+        if let Some(info) = self.cardholder_info.as_ref() {
+            map.insert("cardholderInfo".to_string(), serde_json::json!(info));
+        }
+        if let Some(reason) = self.transaction_status_reason.as_ref() {
+            map.insert(
+                "transactionStatusReason".to_string(),
+                serde_json::json!(reason),
+            );
+        }
+        (!map.is_empty()).then(|| serde_json::Value::Object(map))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1067,9 +1934,15 @@ pub struct FiservemeaPaymentsResponse {
     fiservemea_type: Option<String>,
     client_request_id: Option<String>,
     api_trace_id: Option<String>,
-    ipg_transaction_id: String,
+    // Opcionales a propósito: el gateway devuelve respuestas reales sin estos dos campos
+    // (p. ej. el rechazo de "Unable to verify card enrollment" llega sin `ipgTransactionId`
+    // ni `transactionType`, sólo con `transactionStatus`/`error`). Exigirlos hacía que la
+    // respuesta entera no parseara y se perdiera incluso el motivo del rechazo; peor aún,
+    // bastaría una respuesta aprobada sin uno de los dos para transformar un cobro real en
+    // un error de deserialización.
+    ipg_transaction_id: Option<String>,
     order_id: Option<String>,
-    transaction_type: FiservemeaTransactionType,
+    transaction_type: Option<FiservemeaTransactionType>,
     transaction_origin: Option<FiservemeaTransactionOrigin>,
     payment_method_details: Option<FiservemeaPaymentMethodDetails>,
     country: Option<Secret<String>>,
@@ -1085,6 +1958,11 @@ pub struct FiservemeaPaymentsResponse {
     error_message: Option<String>,
     transaction_state: Option<String>,
     scheme_transaction_id: Option<String>,
+    /// El gateway devuelve `paymentToken` en casi toda respuesta de pago, pero con `value`
+    /// **sólo** cuando efectivamente hay un token reusable (verificado sobre las respuestas
+    /// capturadas: 518 lo traen sin `value` y 19 con él). Es el `hosted-data-id` que se reusa
+    /// para cobrar Card on File, así que cuando viene se publica como referencia de mandato.
+    payment_token: Option<FiservemeaResponsePaymentToken>,
     processor: Option<Processor>,
     // Present only on 3DS Authorize/CompleteAuthorize responses; `None` for
     // capture/void/refund responses, which is what keeps those flows unaffected.
@@ -1111,6 +1989,84 @@ impl FiservemeaPaymentsResponse {
     }
 }
 
+/// Cuerpo que devuelve la consulta por orden (`GET /orders/{orderId}?storeId=...`).
+///
+/// La guía (§7.3) dice que al endpoint de consulta se le manda "el identificador de la
+/// transacción u orden" y que se recibe "un Payload de tipo TransactionResponse u
+/// OrderResponse respectivamente": consultando por orden los datos de la transacción no
+/// vienen arriba sino dentro del array `transactions`, así que hace falta un struct propio.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiservemeaOrderResponse {
+    #[serde(rename = "type")]
+    fiservemea_type: Option<String>,
+    client_request_id: Option<String>,
+    api_trace_id: Option<String>,
+    order_id: Option<String>,
+    transactions: Vec<FiservemeaPaymentsResponse>,
+}
+
+/// Respuesta del PSync, que según por dónde se haya consultado llega con una forma u otra.
+///
+/// Se discrimina por el campo `type`, que el gateway manda siempre (verificado sobre las
+/// respuestas capturadas: 450 `transactionResponse` y 12 `orderResponse`, ninguna sin él).
+///
+/// No va `untagged` por dos motivos. El primero es de corrección: las dos formas dejaron de
+/// ser disjuntas por estructura cuando `ipgTransactionId` y `transactionType` pasaron a ser
+/// opcionales, así que un `orderResponse` puede satisfacer la forma de transacción y
+/// deserializarse como tal, perdiendo el array `transactions`. Con `untagged` eso dependía
+/// del orden de declaración de las variantes, que es una garantía demasiado frágil. El
+/// segundo es de diagnóstico: `untagged` colapsa cualquier error de parseo en
+/// "data did not match any variant", que no dice qué campo falló.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum FiservemeaSyncResponse {
+    #[serde(rename = "orderResponse")]
+    Order(FiservemeaOrderResponse),
+    #[serde(rename = "transactionResponse")]
+    Transaction(Box<FiservemeaPaymentsResponse>),
+}
+
+impl FiservemeaSyncResponse {
+    /// Deja una única transacción para que el resto del PSync siga siendo el de siempre.
+    ///
+    /// De una orden con varias transacciones se toma la **primera**. Verificado en vivo
+    /// contra cert: IPG las devuelve en orden cronológico y la primaria va al frente
+    /// (`PX-1786053427-07-void` → `[SALE 84667286296, VOID 84667286297]`,
+    /// `PX-1786053434-09-retpar` → `[SALE 84667286310, RETURN 84667286311]`). La primaria
+    /// es la que le corresponde al intento de pago que el PSync está consultando; las
+    /// secundarias (VOID/RETURN/POSTAUTH) son otros flujos de Hyperswitch, que sincronizan
+    /// con su propio id (RSync para los refunds). Quedarse con la última sería activamente
+    /// peor: en una orden con devolución parcial la última es el RETURN y `map_status` lo
+    /// mapea a `Failure`, o sea que un pago cobrado se reportaría como fallido.
+    pub fn into_transaction(
+        self,
+    ) -> Result<FiservemeaPaymentsResponse, error_stack::Report<errors::ConnectorError>> {
+        match self {
+            Self::Transaction(transaction) => Ok(*transaction),
+            Self::Order(order) => {
+                let total = order.transactions.len();
+                if total > 1 {
+                    // Se avisa en vez de callar: si alguna vez el orden dejara de ser
+                    // cronológico, el log es la única pista de que se eligió mal.
+                    router_env::logger::warn!(
+                        transactions_in_order = total,
+                        order_id = ?order.order_id,
+                        "fiservemea orderResponse carries multiple transactions; syncing with the first (primary) one"
+                    );
+                }
+                order.transactions.into_iter().next().ok_or_else(|| {
+                    // Una orden sin transacciones no permite decidir ningún estado: es
+                    // preferible que el PSync falle a inventar un `Pending` o un `Failure`.
+                    error_stack::Report::new(errors::ConnectorError::MissingRequiredField {
+                        field_name: "transactions",
+                    })
+                })
+            }
+        }
+    }
+}
+
 impl<F, T> TryFrom<ResponseRouterData<F, FiservemeaPaymentsResponse, T, PaymentsResponseData>>
     for RouterData<F, T, PaymentsResponseData>
 {
@@ -1126,11 +2082,15 @@ impl<F, T> TryFrom<ResponseRouterData<F, FiservemeaPaymentsResponse, T, Payments
             .response
             .authentication_response
             .as_ref()
-            .and_then(|auth| auth.to_redirection());
+            // La conversión genérica no ve el request, así que acá no hay `complete_authorize_url`.
+            // El wrapper del methodForm se aplica después, en el `handle_response` de Authorize,
+            // que es el único lugar con acceso a esa URL.
+            .and_then(|auth| auth.to_redirection(None));
         let mapped_status = map_status(
             item.response.transaction_status,
             item.response.transaction_result,
             item.response.transaction_type,
+            item.response.transaction_state.as_deref(),
         );
         // Only treat the payment as awaiting authentication when it carries actionable 3DS
         // redirect data AND has not already reached a terminal outcome. A terminal response
@@ -1145,20 +2105,106 @@ impl<F, T> TryFrom<ResponseRouterData<F, FiservemeaPaymentsResponse, T, Payments
         // present. It never influences status (that's `map_status`'s job); it's only attached so
         // it shows up in logs/analytics instead of being silently dropped. Absent on non-3DS and
         // intermediate 3DS responses, so `connector_metadata` stays `None` there as before.
-        let connector_metadata = item
+        // Al `responseCode3dSecure` se le suma el emparejamiento Network Token ↔ PAN cuando la
+        // transacción se procesó con tokenización de marca. Es el dato que el manual de Network
+        // Token exige guardar en cada transacción aprobada para poder conciliar y atender
+        // desconocimientos, porque lo que vuelve del procesador es el token y no el PAN.
+        let three_ds_code = item
             .response
             .secure3d_response
             .as_ref()
-            .and_then(|secure3d| secure3d.response_code3d_secure.as_ref())
-            .map(|code| serde_json::json!({ "responseCode3dSecure": code }));
+            .and_then(|secure3d| secure3d.to_metadata());
+        let token_pairing = item
+            .response
+            .payment_method_details
+            .as_ref()
+            .and_then(|details| details.network_token_pairing());
+        let connector_metadata = match (three_ds_code, token_pairing) {
+            (None, None) => None,
+            (code, pairing) => {
+                let mut map = serde_json::Map::new();
+                if let Some(serde_json::Value::Object(three_ds)) = code {
+                    map.extend(three_ds);
+                }
+                // `to_value` sobre este struct no puede fallar (sólo strings), pero si alguna vez
+                // fallara, perder el emparejamiento no justifica tirar abajo un cobro aprobado.
+                if let Some(value) = pairing.and_then(|p| serde_json::to_value(p).ok()) {
+                    map.insert("networkTokenPairing".to_string(), value);
+                }
+                Some(serde_json::Value::Object(map))
+            }
+        };
+
+        // Un rechazo de IPG llega con HTTP 2xx y sólo se distingue por el estado, así
+        // que sin esto el pago quedaba en Failure sin código ni motivo. El código real
+        // viene en `processor.responseCode` y el texto en `processor.responseMessage`;
+        // `approvalCode` los trae juntos con el formato `N:<código>:<texto>`.
+        if status == common_enums::AttemptStatus::Failure {
+            let (approval_code, approval_message) =
+                split_approval_code(item.response.approval_code.as_deref());
+            let processor = item.response.processor.as_ref();
+            let code = processor
+                .and_then(|p| p.response_code.clone())
+                .or(approval_code)
+                .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string());
+            let message = processor
+                .and_then(|p| p.response_message.clone())
+                .or_else(|| item.response.error_message.clone())
+                .or(approval_message)
+                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string());
+            let network = FiservemeaNetworkCodes::from_processor(processor);
+            return Ok(Self {
+                status,
+                response: Err(ErrorResponse {
+                    code,
+                    message: message.clone(),
+                    reason: Some(message),
+                    status_code: item.http_code,
+                    attempt_status: Some(status),
+                    // `ipgTransactionId` es opcional: el gateway lo omite en los rechazos que
+                    // fallan antes de crear la transacción (por ejemplo el 409 de Data Only).
+                    connector_transaction_id: item.response.ipg_transaction_id,
+                    network_decline_code: network.decline_code,
+                    network_advice_code: network.advice_code,
+                    network_error_message: network.error_message,
+                    connector_metadata: connector_metadata.map(Secret::new),
+                }),
+                ..item.data
+            });
+        }
+
         Ok(Self {
             status,
             response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.ipg_transaction_id),
+                // Si el gateway omitió el id, se prefiere registrar el intento con el estado
+                // real (y sin id para sincronizar) antes que descartar la respuesta entera:
+                // un cobro sin id sigue siendo un cobro que el comercio tiene que ver.
+                resource_id: item
+                    .response
+                    .ipg_transaction_id
+                    .map_or(ResponseId::NoResponseId, ResponseId::ConnectorTransactionId),
                 redirection_data: Box::new(redirection_data),
-                mandate_reference: Box::new(None),
+                // El token del gateway es lo que permite volver a cobrar la tarjeta guardada:
+                // sin publicarlo como referencia de mandato, el token vive sólo dentro de la
+                // ejecución que lo creó y Card on File no se puede encadenar.
+                mandate_reference: Box::new(
+                    item.response
+                        .payment_token
+                        .as_ref()
+                        .and_then(|token| token.value.clone())
+                        .map(|value| MandateReference {
+                            connector_mandate_id: Some(value.expose()),
+                            payment_method_id: None,
+                            mandate_metadata: None,
+                            connector_mandate_request_reference_id: None,
+                        }),
+                ),
                 connector_metadata,
-                network_txn_id: None,
+                // Visa exige guardar el `schemeTransactionId` de la transacción original y
+                // devolverlo en `referencedSchemeTransactionId` en los REPEAT del ciclo
+                // recurrente. Hyperswitch lo persiste como `network_txn_id`; antes se parseaba
+                // de la respuesta y se descartaba, así que la recurrencia Visa no se podía armar.
+                network_txn_id: item.response.scheme_transaction_id.clone(),
                 connector_response_reference_id: item.response.order_id,
                 incremental_authorization_allowed: None,
                 charges: None,
@@ -1212,10 +2258,12 @@ pub struct FiservemeaVoidRequest {
 // be unit-tested without constructing a full `PaymentsCancelRouterData`.
 fn select_void_request_type(capture_method: Option<enums::CaptureMethod>) -> FiservemeaRequestType {
     if is_auto_capture(capture_method) {
+        // Incluye `None`: en la API de Hyperswitch significa captura automática, o sea
+        // que el pago se envió como `PaymentCardSaleTransaction` y se anula con
+        // `VoidTransaction`. Mantiene la selección alineada con la de Authorize.
         FiservemeaRequestType::VoidTransaction
     } else {
-        // Manual capture (or no capture-method signal at all) is treated as a pre-auth void,
-        // preserving the connector's previous default behavior.
+        // Sólo la captura manual explícita corresponde a un pre-auth sin capturar.
         FiservemeaRequestType::VoidPreAuthTransactions
     }
 }
@@ -1255,34 +2303,54 @@ impl<F> TryFrom<&FiservemeaRouterData<&RefundsRouterData<F>>> for FiservemeaRefu
     }
 }
 
+/// Estado con el que se resuelve un reembolso que el gateway ya ejecutó pero cuyo desenlace no
+/// se puede clasificar. `Pending` en vez de un error: el `RETURN` viajó al gateway, y devolver
+/// `Failure`/error deja el reembolso como reintentable, o sea habilita un segundo pago al
+/// tarjetahabiente. `Pending` no confirma nada y deja que el RSync resuelva.
+const UNKNOWN_REFUND_STATUS: enums::RefundStatus = enums::RefundStatus::Pending;
+
 fn map_refund_status(
     fiservemea_status: Option<FiservemeaPaymentStatus>,
     fiservemea_result: Option<FiservemeaPaymentResult>,
-) -> Result<enums::RefundStatus, errors::ConnectorError> {
-    match fiservemea_status {
-        Some(status) => match status {
-            FiservemeaPaymentStatus::Approved => Ok(enums::RefundStatus::Success),
-            FiservemeaPaymentStatus::Partial | FiservemeaPaymentStatus::Waiting => {
-                Ok(enums::RefundStatus::Pending)
-            }
+) -> enums::RefundStatus {
+    // Mismo criterio que en `map_status`: el campo deprecado sólo decide cuando trae un valor
+    // conocido, si no manda el `transactionResult` vigente.
+    let from_status = match fiservemea_status {
+        Some(FiservemeaPaymentStatus::Approved) => Some(enums::RefundStatus::Success),
+        Some(FiservemeaPaymentStatus::Partial | FiservemeaPaymentStatus::Waiting) => {
+            Some(enums::RefundStatus::Pending)
+        }
+        Some(
             FiservemeaPaymentStatus::ValidationFailed
             | FiservemeaPaymentStatus::ProcessingFailed
-            | FiservemeaPaymentStatus::Declined => Ok(enums::RefundStatus::Failure),
-        },
-        None => match fiservemea_result {
-            Some(result) => match result {
-                FiservemeaPaymentResult::Approved => Ok(enums::RefundStatus::Success),
-                FiservemeaPaymentResult::Partial | FiservemeaPaymentResult::Waiting => {
-                    Ok(enums::RefundStatus::Pending)
-                }
-                FiservemeaPaymentResult::Declined
-                | FiservemeaPaymentResult::Failed
-                | FiservemeaPaymentResult::Fraud => Ok(enums::RefundStatus::Failure),
-            },
-            None => Err(errors::ConnectorError::MissingRequiredField {
-                field_name: "transactionResult",
-            }),
-        },
+            | FiservemeaPaymentStatus::Declined,
+        ) => Some(enums::RefundStatus::Failure),
+        Some(FiservemeaPaymentStatus::Unknown) | None => None,
+    };
+    if let Some(status) = from_status {
+        return status;
+    }
+
+    match fiservemea_result {
+        Some(FiservemeaPaymentResult::Approved) => enums::RefundStatus::Success,
+        Some(FiservemeaPaymentResult::Partial | FiservemeaPaymentResult::Waiting) => {
+            enums::RefundStatus::Pending
+        }
+        Some(
+            FiservemeaPaymentResult::Declined
+            | FiservemeaPaymentResult::Failed
+            | FiservemeaPaymentResult::Fraud,
+        ) => enums::RefundStatus::Failure,
+        Some(FiservemeaPaymentResult::Unknown) | None => {
+            // Igual que en `map_status`: el descarte no puede ser mudo. Un reembolso que queda
+            // en Pending sin rastro de por qué es indiagnosticable después.
+            router_env::logger::warn!(
+                transaction_status = ?fiservemea_status,
+                transaction_result = ?fiservemea_result,
+                "fiservemea: estado de reembolso no contemplado; se difiere al RSync"
+            );
+            UNKNOWN_REFUND_STATUS
+        }
     }
 }
 
@@ -1295,11 +2363,19 @@ impl TryFrom<RefundsResponseRouterData<Execute, FiservemeaPaymentsResponse>>
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             response: Ok(RefundsResponseData {
-                connector_refund_id: item.response.ipg_transaction_id,
+                // A diferencia del pago, acá no hay equivalente a `NoResponseId`: sin el id del
+                // `RETURN` el RSync apuntaría al id del pago original y leería el estado del
+                // cobro como si fuera el del reembolso. Se falla con el campo concreto que
+                // faltó, que es accionable, en vez de con un error de deserialización opaco.
+                connector_refund_id: item.response.ipg_transaction_id.ok_or(
+                    errors::ConnectorError::MissingRequiredField {
+                        field_name: "ipgTransactionId",
+                    },
+                )?,
                 refund_status: map_refund_status(
                     item.response.transaction_status,
                     item.response.transaction_result,
-                )?,
+                ),
             }),
             ..item.data
         })
@@ -1315,11 +2391,16 @@ impl TryFrom<RefundsResponseRouterData<RSync, FiservemeaPaymentsResponse>>
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             response: Ok(RefundsResponseData {
-                connector_refund_id: item.response.ipg_transaction_id,
+                // Ver la nota del flujo Execute: el id del reembolso no admite fallback.
+                connector_refund_id: item.response.ipg_transaction_id.ok_or(
+                    errors::ConnectorError::MissingRequiredField {
+                        field_name: "ipgTransactionId",
+                    },
+                )?,
                 refund_status: map_refund_status(
                     item.response.transaction_status,
                     item.response.transaction_result,
-                )?,
+                ),
             }),
             ..item.data
         })
@@ -1339,19 +2420,46 @@ pub struct FiservemeaError {
     pub details: Option<Vec<ErrorDetails>>,
 }
 
+// El gateway serializa en camelCase (clientRequestId, apiTraceId, responseType).
+// Sin este rename_all los tres campos quedaban siempre en None, y el apiTraceId
+// es justamente el identificador con el que Fiserv busca la transacción en sus logs.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FiservemeaErrorResponse {
     #[serde(rename = "type")]
     fiservemea_type: Option<String>,
-    client_request_id: Option<String>,
-    api_trace_id: Option<String>,
+    pub client_request_id: Option<String>,
+    pub api_trace_id: Option<String>,
     pub response_type: Option<String>,
     pub error: Option<FiservemeaError>,
+    /// Un rechazo del emisor llega con HTTP 422 y `responseType: EndpointDeclined` (verificado
+    /// contra cert: monto 1005 → `responseCode: "05"`, `responseMessage: "Do not honour"`), o
+    /// sea que cae en `build_error_response` y no en el `TryFrom` de la respuesta. Sin parsear
+    /// acá el bloque `processor`, los códigos de red del único camino por el que pasan los
+    /// rechazos reales se perdían.
+    pub processor: Option<Processor>,
+    /// El gateway sí devuelve el id de transacción en la mayoría de los rechazos (90 de 107
+    /// respuestas de error capturadas contra cert lo traen; los 17 que no son los que fallan
+    /// antes de crear la transacción, como el `INVALID_INPUT` por payload inválido). Sin
+    /// declararlo acá se descartaba justo en el camino de los rechazos del emisor, y sin id no
+    /// se puede consultar ni conciliar la transacción después.
+    pub ipg_transaction_id: Option<String>,
+    /// El resultado de la autenticación 3DS también llega en el camino de error, y es el dato que
+    /// el checklist de homologación pide reportar por caso: 11 de las 22 filas 3DS terminan en un
+    /// HTTP 409 con `secure3dResponse.responseCode3dSecure` (los "Not Authenticated" y
+    /// "Rejected", que cierran por diseño en `N:-50716`). Sin declararlo acá se descartaba
+    /// justamente en las filas donde hace falta.
+    pub secure3d_response: Option<FiservemeaSecure3dResponse>,
 }
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::indexing_slicing, clippy::panic)]
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
 
     use super::*;
 
@@ -1413,11 +2521,13 @@ mod tests {
         let order = FiservemeaOrder {
             order_id: "ord_1".to_string(),
             installment_options: Some(FiservemeaInstallmentOptions {
-                number_of_installments: 6,
+                number_of_installments: Some(6),
+                recurring_type: None,
                 interest: Some(true),
             }),
             additional_details: None,
             soft_descriptor: None,
+            token_cryptogram: None,
         };
         let json = serde_json::to_value(&order).unwrap();
         assert_eq!(json["installmentOptions"]["numberOfInstallments"], 6);
@@ -1475,27 +2585,253 @@ mod tests {
             soft_descriptor: Some(FiservemeaSoftDescriptor {
                 dynamic_merchant_name: Secret::new("PXSOL*Reservas".to_string()),
             }),
+            token_cryptogram: None,
         };
         let json = serde_json::to_value(&order).unwrap();
         assert_eq!(json["softDescriptor"]["dynamicMerchantName"], "PXSOL*Reservas");
     }
 
+    /// Metadata del comercio a partir de un objeto JSON, sin `frm_metadata`.
+    fn meta_from_json(value: serde_json::Value) -> FiservemeaMetadataObject {
+        FiservemeaMetadataObject::from_sources(Some(&value), None)
+    }
+
+    /// URL de retorno usada en los tests de `authenticationRequest`; el conector manda la misma
+    /// en `termURL` y en `methodNotificationURL`.
+    const TEST_RETURN_URL: &str = "https://www.pxsol.com/3ds/return";
+
+    fn auth_request_json(metadata: serde_json::Value) -> serde_json::Value {
+        auth_request_json_for_brand(metadata, true)
+    }
+
+    /// `is_mastercard` decide si Data Only aplica: la modalidad es exclusiva de Mastercard.
+    fn auth_request_json_for_brand(
+        metadata: serde_json::Value,
+        is_mastercard: bool,
+    ) -> serde_json::Value {
+        let meta = meta_from_json(metadata);
+        let request = FiservemeaAuthenticationRequest::new(
+            TEST_RETURN_URL.to_string(),
+            TEST_RETURN_URL.to_string(),
+            &meta,
+            is_mastercard,
+        )
+        .unwrap();
+        serde_json::to_value(&request).unwrap()
+    }
+
     #[test]
     fn authentication_request_locks_wire_values() {
-        // Lock the exact strings the connector sends on the wire (the Authorize `try_from`
-        // emits challengeWindowSize "05" / challengeIndicator "01", and "80" for Data-Only).
-        let req = FiservemeaAuthenticationRequest {
-            authentication_type: "Secure3D21AuthenticationRequest".to_string(),
-            term_url: "https://hyperswitch.io/complete".to_string(),
-            method_notification_url: "https://hyperswitch.io/complete".to_string(),
-            challenge_indicator: Some("01".to_string()),
-            challenge_window_size: Some("05".to_string()),
-            message_category: Some("80".to_string()),
-        };
-        let json = serde_json::to_value(&req).unwrap();
-        assert_eq!(json["challengeIndicator"], "01");
-        assert_eq!(json["challengeWindowSize"], "05");
-        assert_eq!(json["messageCategory"], "80");
+        // El 3DS normal usa la subclase 2.1/2.2 con los defaults del conector y NUNCA
+        // `messageCategory`. Igualdad del objeto completo para que un campo nuevo no se cuele
+        // sin que nadie lo mire.
+        assert_eq!(
+            auth_request_json(serde_json::json!({})),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationRequest",
+                "termURL": TEST_RETURN_URL,
+                "methodNotificationURL": TEST_RETURN_URL,
+                "challengeIndicator": "01",
+                "challengeWindowSize": "05",
+            })
+        );
+    }
+
+    #[test]
+    fn data_only_uses_base_class_and_omits_challenge_fields() {
+        // Payload calcado del ejemplo de la guía §10.1.6 y de la request que el gateway cert
+        // aceptó (apiTraceId anX08HbyIFesn-w_H26JWQAAA88: la clase base con messageCategory 80
+        // pasa la validación de forma y llega a decidirse por negocio).
+        assert_eq!(
+            auth_request_json(serde_json::json!({ "three_ds_data_only": true })),
+            serde_json::json!({
+                "authenticationType": "Secure3DAuthenticationRequest",
+                "termURL": TEST_RETURN_URL,
+                "methodNotificationURL": TEST_RETURN_URL,
+                "messageCategory": "80",
+            })
+        );
+    }
+
+    #[test]
+    fn secure3d21_never_carries_message_category() {
+        // La subclase no declara `messageCategory`: mandárselo tira toda la transacción abajo
+        // con 400 INVALID_INPUT (ver `real_cert_error_for_message_category_on_secure3d21`).
+        // Ninguna combinación de metadata que no sea Data Only puede emitirlo.
+        for metadata in [
+            serde_json::json!({}),
+            serde_json::json!({ "three_ds_data_only": false }),
+            serde_json::json!({ "three_ds_data_only": "false", "challenge_indicator": "05" }),
+            // Un valor no booleano no es un opt-in: cae al 3DS normal, no a Data Only.
+            serde_json::json!({ "three_ds_data_only": "quizas" }),
+        ] {
+            let json = auth_request_json(metadata.clone());
+            assert_eq!(
+                json["authenticationType"], "Secure3D21AuthenticationRequest",
+                "metadata {metadata} debería quedarse en 3DS normal"
+            );
+            assert!(
+                json.get("messageCategory").is_none(),
+                "metadata {metadata} emitió messageCategory sobre la subclase 2.1"
+            );
+        }
+    }
+
+    #[test]
+    fn real_cert_error_for_message_category_on_secure3d21() {
+        // Respuesta literal del gateway cert (HTTP 400) al mandar la subclase 2.1 con
+        // `messageCategory`, que es lo que hacía el conector cuando three_ds_data_only estaba
+        // activo. El `details[]` es la única parte que dice qué campo molestó.
+        let raw = serde_json::json!({
+            "type": "errorResponse",
+            "clientRequestId": "0da890f7-c3a4-40bb-88e2-6083cb9e23b8",
+            "apiTraceId": "anX07XbyIFesn-w_H26JQwAAA-U",
+            "error": {
+                "code": "INVALID_INPUT",
+                "message": "Invalid request input. Please see details below.",
+                "details": [{
+                    "field": "messageCategory",
+                    "message": "No field named 'messageCategory' exists for class Secure3D21AuthenticationRequest"
+                }]
+            }
+        });
+        let parsed: FiservemeaErrorResponse = serde_json::from_value(raw).unwrap();
+        let error = parsed.error.expect("el gateway manda el objeto error");
+        assert_eq!(error.code.as_deref(), Some("INVALID_INPUT"));
+        let details = error.details.expect("INVALID_INPUT trae details");
+        assert_eq!(details[0].field.as_deref(), Some("messageCategory"));
+        assert_eq!(
+            details[0].message.as_deref(),
+            Some(
+                "No field named 'messageCategory' exists for class Secure3D21AuthenticationRequest"
+            )
+        );
+    }
+
+    #[test]
+    fn challenge_fields_come_from_metadata() {
+        // `challengeIndicator: "03"` (desafío pedido) + `challengeWindowSize: "03"` (500x600):
+        // combinación aceptada en vivo por cert, apiTraceId anX08yKQSojaSWQEaFLrlwAAA9o.
+        assert_eq!(
+            auth_request_json(serde_json::json!({
+                "challenge_indicator": "03",
+                "challenge_window_size": "03",
+            })),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationRequest",
+                "termURL": TEST_RETURN_URL,
+                "methodNotificationURL": TEST_RETURN_URL,
+                "challengeIndicator": "03",
+                "challengeWindowSize": "03",
+            })
+        );
+    }
+
+    #[test]
+    fn challenge_fields_accept_camel_case_aliases_and_integers() {
+        let meta = meta_from_json(serde_json::json!({
+            "challengeIndicator": 4,
+            "challengeWindowSize": " 2 ",
+        }));
+        assert_eq!(meta.challenge_indicator.as_deref(), Some("04"));
+        assert_eq!(meta.challenge_window_size.as_deref(), Some("02"));
+    }
+
+    #[test]
+    fn null_or_blank_challenge_fields_fall_back_to_the_defaults() {
+        // Un opcional que el cliente serializó como `null`/`""` no es una configuración
+        // inválida: si lo tratáramos como tal, romperíamos pagos que hoy funcionan.
+        assert_eq!(
+            auth_request_json(serde_json::json!({
+                "challenge_indicator": null,
+                "challenge_window_size": "  ",
+            })),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationRequest",
+                "termURL": TEST_RETURN_URL,
+                "methodNotificationURL": TEST_RETURN_URL,
+                "challengeIndicator": "01",
+                "challengeWindowSize": "05",
+            })
+        );
+    }
+
+    #[test]
+    fn challenge_fields_fall_back_to_frm_metadata() {
+        let frm = serde_json::json!({ "challenge_window_size": "04" });
+        let meta = FiservemeaMetadataObject::from_sources(
+            Some(&serde_json::json!({ "challenge_indicator": "02" })),
+            Some(&frm),
+        );
+        assert_eq!(meta.challenge_indicator.as_deref(), Some("02"));
+        assert_eq!(meta.challenge_window_size.as_deref(), Some("04"));
+    }
+
+    #[test]
+    fn out_of_range_challenge_values_are_rejected() {
+        // El gateway también los rechaza, pero con un 400 sin `code` ni `details`
+        // ("Error parsing json. Erroneous Field: authenticationRequest.challengeIndicator.
+        // Cause: Unexpected value '99'"), imposible de atribuir a la metadata del comercio.
+        // Y descartarlos en silencio caería al default, que puede autenticar más flojo.
+        for bad in ["99", "10", "00", "0", "abc", "true"] {
+            let meta = meta_from_json(serde_json::json!({ "challenge_indicator": bad }));
+            assert!(
+                FiservemeaAuthenticationRequest::new(
+                    TEST_RETURN_URL.to_string(),
+                    TEST_RETURN_URL.to_string(),
+                    &meta,
+                    true
+                )
+                .is_err(),
+                "challenge_indicator {bad:?} debería rechazarse"
+            );
+        }
+        // El tamaño de ventana NO hace fallar el pago: no es un parámetro de autenticación,
+        // así que un valor fuera de rango cae al default. `06` es un indicador válido pero no
+        // un tamaño válido, y sirve para comprobar que no se confunden las dos listas.
+        for bad in ["06", "09", "0", "grande"] {
+            let json = auth_request_json(serde_json::json!({ "challenge_window_size": bad }));
+            assert_eq!(
+                json["challengeWindowSize"], FISERVEMEA_DEFAULT_CHALLENGE_WINDOW_SIZE,
+                "challenge_window_size {bad:?} debería caer al default"
+            );
+        }
+    }
+
+    #[test]
+    fn data_only_is_ignored_on_a_card_that_is_not_mastercard() {
+        // Data Only es exclusivo de Mastercard: con una Visa el gateway responde
+        // `50738 "Invalid Message Category"` (verificado contra cert). Si el comercio deja la
+        // bandera como default global, sus ventas Visa tienen que seguir andando por 3DS
+        // normal en vez de fallar todas.
+        let json = auth_request_json_for_brand(
+            serde_json::json!({ "three_ds_data_only": true }),
+            false,
+        );
+        assert_eq!(json["authenticationType"], FISERVEMEA_AUTH_TYPE_SECURE3D21);
+        assert!(json.get("messageCategory").is_none());
+        assert_eq!(json["challengeIndicator"], FISERVEMEA_DEFAULT_CHALLENGE_INDICATOR);
+
+        // Y con Mastercard sí sale Data Only, con la clase base y sin campos de desafío.
+        let json =
+            auth_request_json_for_brand(serde_json::json!({ "three_ds_data_only": true }), true);
+        assert_eq!(json["authenticationType"], FISERVEMEA_AUTH_TYPE_SECURE3D_BASE);
+        assert_eq!(json["messageCategory"], FISERVEMEA_MESSAGE_CATEGORY_DATA_ONLY);
+        assert!(json.get("challengeIndicator").is_none());
+        assert!(json.get("challengeWindowSize").is_none());
+    }
+
+    #[test]
+    fn every_documented_challenge_value_is_accepted() {
+        // Lista completa de la guía §10.1.1 (pág. 31): indicador 01..09, ventana 01..05.
+        for indicator in FISERVEMEA_CHALLENGE_INDICATORS {
+            let json = auth_request_json(serde_json::json!({ "challenge_indicator": indicator }));
+            assert_eq!(json["challengeIndicator"], indicator);
+        }
+        for size in FISERVEMEA_CHALLENGE_WINDOW_SIZES {
+            let json = auth_request_json(serde_json::json!({ "challenge_window_size": size }));
+            assert_eq!(json["challengeWindowSize"], size);
+        }
     }
 
     #[test]
@@ -1550,6 +2886,7 @@ mod tests {
             response.transaction_status,
             response.transaction_result,
             response.transaction_type,
+            response.transaction_state.as_deref(),
         );
         assert_eq!(status, common_enums::AttemptStatus::Charged);
     }
@@ -1635,14 +2972,17 @@ mod tests {
     }
 
     #[test]
-    fn void_request_type_manual_or_missing_capture_selects_preauth_void() {
+    fn void_request_type_only_manual_capture_selects_preauth_void() {
         assert!(matches!(
             select_void_request_type(Some(enums::CaptureMethod::Manual)),
             FiservemeaRequestType::VoidPreAuthTransactions
         ));
+        // `None` es captura automática: el pago se envió como sale, así que se anula
+        // con VoidTransaction. Antes esto elegía VoidPreAuthTransactions y fallaba
+        // al anular una venta creada sin capture_method explícito.
         assert!(matches!(
             select_void_request_type(None),
-            FiservemeaRequestType::VoidPreAuthTransactions
+            FiservemeaRequestType::VoidTransaction
         ));
     }
 
@@ -1650,6 +2990,7 @@ mod tests {
         authentication_request: Option<FiservemeaAuthenticationRequest>,
     ) -> FiservemeaPaymentsRequest {
         FiservemeaPaymentsRequest {
+            stored_credentials: None,
             request_type: FiservemeaRequestType::PaymentCardSaleTransaction,
             store_id: Secret::new("teststore".to_string()),
             merchant_transaction_id: "mtx_1".to_string(),
@@ -1662,6 +3003,7 @@ mod tests {
                 installment_options: None,
                 additional_details: None,
                 soft_descriptor: None,
+                token_cryptogram: None,
             },
             payment_method: FiservemeaPaymentMethods::PaymentCard(FiservemeaPaymentCard {
                 number: "4111111111111111".parse().unwrap(),
@@ -1669,7 +3011,7 @@ mod tests {
                     month: Secret::new("12".to_string()),
                     year: Secret::new("30".to_string()),
                 },
-                security_code: Secret::new("123".to_string()),
+                security_code: Some(Secret::new("123".to_string())),
                 cardholder_name: None,
             }),
             authentication_request,
@@ -1719,7 +3061,7 @@ mod tests {
             }),
             params: None,
         };
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Html { html_data }) => {
                 assert_eq!(html_data, "<form id=\"tds\"></form>");
             }
@@ -1740,7 +3082,7 @@ mod tests {
                 sessiondata: Some("session_value".to_string()),
             }),
         };
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Form {
                 endpoint,
                 method,
@@ -1768,7 +3110,7 @@ mod tests {
             secure3d_method: None,
             params: None,
         };
-        assert!(auth.to_redirection().is_none());
+        assert!(auth.to_redirection(None).is_none());
     }
 
     #[test]
@@ -1786,7 +3128,7 @@ mod tests {
             },
         });
         let auth: FiservemeaAuthenticationResponse = serde_json::from_value(json).unwrap();
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Html { html_data }) => {
                 assert_eq!(html_data, "<form id=\"tds-alt\"></form>");
             }
@@ -1810,7 +3152,7 @@ mod tests {
             },
         });
         let auth: FiservemeaAuthenticationResponse = serde_json::from_value(json).unwrap();
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Form { form_fields, .. }) => {
                 assert_eq!(
                     form_fields.get("threeDSSessionData"),
@@ -1996,6 +3338,462 @@ mod tests {
         assert!(request.method_notification_status.is_none());
     }
 
+    // =====================================================================================
+    // Los 21 casos 3DS del checklist y los pasos de continuación, contra los requests
+    // REALES que el gateway de certificación aceptó
+    // (fiserv_homologacion_logs/20260806-215656/evidencia.jsonl).
+    //
+    // La única diferencia legítima con la evidencia son las dos URLs de callback: el harness
+    // usó dos paths distintos (`/3ds/return` y `/3ds/method`) y el conector, que sólo tiene el
+    // `complete_authorize_url` de Hyperswitch, distingue con el marcador `fiservemea3ds`. Que
+    // esa forma también sirve está verificado en vivo: la misma venta frictionless con estas
+    // URLs salió APPROVED con `responseCode3dSecure: 1`
+    // (ipgTransactionId 84668171318, apiTraceId an0HWCR5qsxv6kPs1WrZ4wAAAc0).
+    // =====================================================================================
+
+    /// `complete_authorize_url` de Hyperswitch: una sola URL para los dos callbacks.
+    const THREE_DS_COMPLETE_AUTHORIZE_URL: &str =
+        "https://sandbox.hyperswitch.io/payments/redirect/pay_abc/merch_1/pm_1";
+    /// Retorno del navegador (ventana principal): es el que lleva el PATCH de continuación.
+    const THREE_DS_TERM_URL: &str =
+        "https://sandbox.hyperswitch.io/payments/redirect/pay_abc/merch_1/pm_1?fiservemea3ds=term";
+    /// Notificación que el ACS publica dentro del iframe oculto: no continúa nada.
+    const THREE_DS_METHOD_URL: &str =
+        "https://sandbox.hyperswitch.io/payments/redirect/pay_abc/merch_1/pm_1?fiservemea3ds=method";
+
+    /// `authenticationRequest` que el gateway aceptó en los 20 casos 3DS que no son Data Only
+    /// (evidencia.jsonl líneas 18-56), con las URLs del conector en lugar de las del harness.
+    fn expected_secure3d21_auth_request(
+        challenge_indicator: &str,
+        challenge_window_size: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "authenticationType": "Secure3D21AuthenticationRequest",
+            "termURL": THREE_DS_TERM_URL,
+            "methodNotificationURL": THREE_DS_METHOD_URL,
+            "challengeIndicator": challenge_indicator,
+            "challengeWindowSize": challenge_window_size,
+        })
+    }
+
+    /// Venta 3DS completa tal como la arma el conector: `auth_type = ThreeDs` +
+    /// `complete_authorize_url`, que es lo único que hace aparecer el `authenticationRequest`.
+    fn three_ds_sale_payload(
+        card_number: &str,
+        metadata: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        let mut request = cert_authorize_data(
+            cert_card_data(card_number),
+            100_000,
+            common_enums::Currency::ARS,
+            metadata,
+        );
+        request.complete_authorize_url = Some(THREE_DS_COMPLETE_AUTHORIZE_URL.to_string());
+        let mut router_data: PaymentsAuthorizeRouterData =
+            cert_router_data(CERT_STORE_AR, "PX-3ds-checklist", request);
+        router_data.auth_type = common_enums::AuthenticationType::ThreeDs;
+        authorize_payload(&router_data)
+    }
+
+    /// Las 21 tarjetas 3DS del checklist de homologación: `(id del caso, tarjeta, flujo)`. Los ids
+    /// son los que usa el harness y aparecen en los `case` de evidencia.jsonl; las tarjetas son
+    /// exactamente las que viajaron en esos `POST /payments`. Los 21 casos son:
+    ///   fric-y/n/a/r/u → Frictionless: Authenticated · Not Authenticated · Attempted · Rejected
+    ///                    · Unable to Authenticate
+    ///   mth-y/n/a/r/u  → 3DSMethod, los mismos cinco resultados
+    ///   cha-r, cha-1/4/3/6 → Challenge: "R" y configurable con responseCode3dSecure 1/4/3/6
+    ///   chm-r, chm-1/4/3/6 → Challenge + 3DSMethod, ídem
+    ///   dataonly       → Data Only de Mastercard (`messageCategory: "80"`)
+    const THREE_DS_CHECKLIST: [(&str, &str, &str); 21] = [
+        ("fric-y", "4147463011110083", "fric"),
+        ("fric-n", "4147463011110091", "fric"),
+        ("fric-a", "4147463011110117", "fric"),
+        ("fric-r", "4147463011110042", "fric"),
+        ("fric-u", "4147463011110067", "fric"),
+        ("mth-y", "4099000000001978", "method"),
+        ("mth-n", "4265880000000015", "method"),
+        ("mth-a", "4149011500000519", "method"),
+        ("mth-r", "4016360000000085", "method"),
+        ("mth-u", "4265880000000080", "method"),
+        ("cha-r", "4147463011110034", "challenge"),
+        ("cha-1", "4147463011110059", "challenge"),
+        ("cha-4", "4147463011110059", "challenge"),
+        ("cha-3", "4147463011110059", "challenge"),
+        ("cha-6", "4147463011110059", "challenge"),
+        ("chm-r", "4149011500000535", "challenge_method"),
+        ("chm-1", "4265880000000064", "challenge_method"),
+        ("chm-4", "4265880000000064", "challenge_method"),
+        ("chm-3", "4265880000000064", "challenge_method"),
+        ("chm-6", "4265880000000064", "challenge_method"),
+        ("dataonly", "5239290700000028", "dataonly"),
+    ];
+
+    /// Los 20 casos que no son Data Only mandan EXACTAMENTE el mismo `authenticationRequest`:
+    /// el flujo (frictionless / 3DSMethod / challenge / challenge+method) lo decide el emisor a
+    /// partir del BIN, no el request. Eso es lo que este test fija: que ninguna de las 20
+    /// tarjetas del checklist se desvíe de la forma que el gateway aceptó.
+    #[test]
+    fn the_20_non_data_only_checklist_cases_send_the_cert_accepted_authentication_request() {
+        let expected = expected_secure3d21_auth_request("01", "05");
+        for (label, card, flow) in THREE_DS_CHECKLIST {
+            if flow == "dataonly" {
+                continue;
+            }
+            let payload = three_ds_sale_payload(card, None);
+            assert_eq!(
+                payload["authenticationRequest"], expected,
+                "caso 3DS `{label}` ({card}, flujo {flow}) no manda el authenticationRequest que \
+                 aceptó cert"
+            );
+            // La venta sigue siendo la misma que en los casos sin 3DS: el 3DS agrega el objeto,
+            // no cambia el tipo de transacción ni el medio de pago.
+            assert_eq!(payload["requestType"], "PaymentCardSaleTransaction");
+            assert_eq!(payload["paymentMethod"]["paymentCard"]["number"], card);
+            assert_eq!(payload["transactionAmount"]["total"], "1000.00");
+        }
+    }
+
+    /// Caso 21: Data Only. La clase es la BASE (`Secure3DAuthenticationRequest`), con
+    /// `messageCategory: "80"` y sin `challengeIndicator` ni `challengeWindowSize` — igualito al
+    /// request de evidencia.jsonl línea 57. Verificado en vivo con las URLs del conector: el
+    /// gateway lo procesa (no es un rechazo de forma) y contesta el 50655 de negocio
+    /// `Unable to verify card enrollment` / `responseCode3dSecure: 8`, que es la tienda sin
+    /// Mastercard Insights habilitado (apiTraceId an0HZZ2Cn6oVn4oVRUS3VAAAAxs).
+    #[test]
+    fn the_data_only_checklist_case_uses_the_base_class_with_message_category_80() {
+        let payload = three_ds_sale_payload(
+            "5239290700000028",
+            Some(serde_json::json!({ "three_ds_data_only": true })),
+        );
+        assert_eq!(
+            payload["authenticationRequest"],
+            serde_json::json!({
+                "authenticationType": "Secure3DAuthenticationRequest",
+                "termURL": THREE_DS_TERM_URL,
+                "methodNotificationURL": THREE_DS_METHOD_URL,
+                "messageCategory": "80",
+            })
+        );
+        // Explícito además de la igualdad de arriba: en Data Only no hay desafío que configurar,
+        // y la clase base tampoco declara esos dos campos.
+        let auth_request = &payload["authenticationRequest"];
+        assert!(auth_request.get("challengeIndicator").is_none());
+        assert!(auth_request.get("challengeWindowSize").is_none());
+    }
+
+    /// La misma tarjeta Mastercard del caso Data Only, pero sin el opt-in, tiene que salir por el
+    /// 3DS normal: `three_ds_data_only` es una bandera del comercio, no algo que se deduzca del
+    /// BIN. Si se filtrara sola, toda venta Mastercard con 3DS iría a Data Only.
+    #[test]
+    fn the_data_only_card_without_the_opt_in_stays_on_normal_three_ds() {
+        let payload = three_ds_sale_payload("5239290700000028", None);
+        assert_eq!(
+            payload["authenticationRequest"],
+            expected_secure3d21_auth_request("01", "05")
+        );
+    }
+
+    /// `challengeIndicator`/`challengeWindowSize` de la metadata llegan al request completo, no
+    /// sólo al constructor. `04`/`03` verificado en vivo (apiTraceId an0HYuOTJZTvEmGNMGldfgAAAvE,
+    /// HTTP 200 WAITING, y el `cReq` del ACS vuelve con `challengeWindowSize: "03"`).
+    #[test]
+    fn checklist_challenge_configurable_takes_the_values_from_metadata() {
+        let payload = three_ds_sale_payload(
+            "4147463011110059",
+            Some(serde_json::json!({
+                "challenge_indicator": "04",
+                "challenge_window_size": "03",
+            })),
+        );
+        assert_eq!(
+            payload["authenticationRequest"],
+            expected_secure3d21_auth_request("04", "03")
+        );
+    }
+
+    /// Sin 3DS no hay `authenticationRequest`: es lo que mantiene los 10 casos básicos del
+    /// checklist byte a byte como los aprobó cert.
+    #[test]
+    fn no_three_ds_sale_carries_no_authentication_request() {
+        let payload = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-sin-3ds",
+            "4147463011110083",
+            100_000,
+            common_enums::Currency::ARS,
+            None,
+        );
+        assert!(payload.get("authenticationRequest").is_none());
+    }
+
+    // ---- Punto 3: las dos URLs de callback tienen que salir distinguibles ----
+
+    /// `build_three_ds_callback_url` ya está cubierto por
+    /// `the_two_three_ds_callbacks_are_distinguishable`; lo que falta cubrir es que las dos URLs
+    /// lleguen distintas AL PAYLOAD que sale a la red, que es lo único que el gateway ve. Si
+    /// salieran iguales, la notificación del ACS (que ocurre en el iframe oculto) y el retorno del
+    /// navegador serían indistinguibles y el PATCH de continuación se mandaría dentro del iframe,
+    /// donde el desafío queda invisible.
+    #[test]
+    fn the_authorize_payload_carries_the_two_callback_urls_apart() {
+        let auth_request =
+            three_ds_sale_payload("4099000000001978", None)["authenticationRequest"].clone();
+        let term = auth_request["termURL"].as_str().unwrap();
+        let method = auth_request["methodNotificationURL"].as_str().unwrap();
+        assert_ne!(term, method, "las dos URLs de callback salieron iguales");
+        assert_eq!(term, THREE_DS_TERM_URL);
+        assert_eq!(method, THREE_DS_METHOD_URL);
+        // El `complete_authorize_url` del comercio se conserva entero: el marcador va como query.
+        for url in [term, method] {
+            assert!(url.starts_with(THREE_DS_COMPLETE_AUTHORIZE_URL));
+        }
+    }
+
+    /// La URL del payload y la que usa el wrapper del `methodForm` para navegar la ventana
+    /// principal tienen que ser LA MISMA: si no, el navegador volvería a un callback que el
+    /// conector no clasifica como retorno y la continuación no saldría nunca.
+    #[test]
+    fn the_method_wrapper_navigates_to_the_same_term_url_that_went_in_the_payload() {
+        let payload = three_ds_sale_payload("4099000000001978", None);
+        let term_url_del_payload = payload["authenticationRequest"]["termURL"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let wrapper = build_three_ds_method_wrapper("<form/>", &term_url_del_payload);
+        assert!(
+            wrapper.contains(&format!("var target = \"{term_url_del_payload}\"")),
+            "el wrapper no navega a la termURL del payload: {wrapper}"
+        );
+    }
+
+    // ---- Punto 3: clasificación de los dos callbacks, con las formas reales ----
+
+    /// `threeDSMethodData` real que el ACS de test publicó en la `methodNotificationURL`
+    /// (evidencia.jsonl línea 23, campo del `methodForm`). Decodificado dice
+    /// `{"threeDSServerTransID": "...", "threeDSMethodNotificationURL": ".../3ds/method?ref=..."}`:
+    /// o sea que el destino de la notificación es la URL del METHOD, nunca la `termURL`.
+    const CERT_THREE_DS_METHOD_DATA: &str = "eyAidGhyZWVEU1NlcnZlclRyYW5zSUQiIDogImVkMjNkYzI4LTRkYmMtNTBlMC04MDAwLTAwMDAwNDRmNzhmMyIsICJ0aHJlZURTTWV0aG9kTm90aWZpY2F0aW9uVVJMIiA6ICJodHRwczovL3d3dy5weHNvbC5jb20vM2RzL21ldGhvZD9yZWY9UFgtMTc4NjA1MzQ2My0xOC0zZHMtbXRoLXkiIH0";
+
+    /// La notificación del ACS: entra por la URL del marcador `method` y trae el
+    /// `threeDSMethodData` en el cuerpo. El conector la tiene que reconocer como notificación
+    /// —no como retorno del navegador— porque ocurre dentro del iframe oculto.
+    #[test]
+    fn the_acs_notification_callback_is_classified_as_the_method_notification() {
+        let acs_notification = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=method".to_string())),
+            payload: Some(Secret::new(serde_json::json!({
+                "threeDSMethodData": CERT_THREE_DS_METHOD_DATA,
+            }))),
+        };
+        assert!(
+            is_acs_method_notification(&acs_notification),
+            "la notificación del ACS se confundió con el retorno del navegador: el PATCH saldría \
+             dentro del iframe oculto"
+        );
+    }
+
+    /// El retorno del navegador después del `methodForm`: entra por la URL del marcador `term`,
+    /// sin cRes y sin `threeDSMethodData` (el wrapper sólo hace `window.location.replace`). Es la
+    /// llamada que SÍ tiene que llevar la continuación.
+    #[test]
+    fn the_browser_return_after_the_method_step_is_the_continuation() {
+        let browser_return = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: None,
+        };
+        assert!(!is_acs_method_notification(&browser_return));
+        let request =
+            build_continuation_request(&browser_return, Secret::new(CERT_STORE_AR.to_string()));
+        assert!(request.method_notification_status.is_some());
+        assert!(request.acs_response.is_none());
+    }
+
+    /// El retorno del navegador después del desafío: el ACS postea el `cRes` a la `termURL`, así
+    /// que llega el marcador `term` y el `cRes` juntos. Tiene que clasificar como retorno y la
+    /// continuación tiene que ser la del `cRes`, no la del método.
+    #[test]
+    fn the_browser_return_after_the_challenge_sends_the_cres() {
+        let browser_return = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: Some(Secret::new(
+                serde_json::json!({ "cRes": CERT_CRES_RESPONSE_1 }),
+            )),
+        };
+        assert!(!is_acs_method_notification(&browser_return));
+        let request =
+            build_continuation_request(&browser_return, Secret::new(CERT_STORE_AR.to_string()));
+        assert_eq!(
+            request.acs_response.as_ref().map(|acs| acs.c_res.as_str()),
+            Some(CERT_CRES_RESPONSE_1)
+        );
+        assert!(request.method_notification_status.is_none());
+    }
+
+    /// El marcador manda por sobre el contenido: si el ACS reenvía su notificación con el
+    /// `threeDSMethodData` a la URL del método, sigue siendo notificación aunque el cuerpo se
+    /// parezca al de un retorno. Al revés también: `term` es retorno aunque venga con
+    /// `threeDSMethodData`.
+    #[test]
+    fn the_callback_marker_decides_the_classification_not_the_body() {
+        let method_con_cres = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=method".to_string())),
+            payload: Some(Secret::new(
+                serde_json::json!({ "cRes": "no-deberia-continuar" }),
+            )),
+        };
+        assert!(is_acs_method_notification(&method_con_cres));
+
+        let term_con_method_data = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new(format!(
+                "fiservemea3ds=term&threeDSMethodData={CERT_THREE_DS_METHOD_DATA}"
+            ))),
+            payload: None,
+        };
+        assert!(!is_acs_method_notification(&term_con_method_data));
+    }
+
+    // ---- Punto 2: los bodies de continuación, iguales a los PATCH que cert aceptó ----
+
+    /// `cRes` real que el ACS de test devolvió en "Challenge - configurable / response 1"
+    /// (evidencia.jsonl línea 35), el que el gateway aceptó con HTTP 200.
+    const CERT_CRES_RESPONSE_1: &str = "ewogICJhY3NUcmFuc0lEIiA6ICJlZmYzYmFhNi0zYzU4LTQzOTEtODY0Ni1mZGMwMDc4M2Q5YmMiLAogICJtZXNzYWdlVHlwZSIgOiAiQ1JlcyIsCiAgIm1lc3NhZ2VWZXJzaW9uIiA6ICIyLjIuMCIsCiAgInRocmVlRFNTZXJ2ZXJUcmFuc0lEIiA6ICI1MmEzNGMwOC1mZjAxLTU1ZTItODAwMC0wMDAwMDQ0Zjc5NTciLAogICJ0cmFuc1N0YXR1cyIgOiAiWSIKfQ";
+
+    /// Serializa el body de continuación por el mismo camino que `get_request_body`.
+    fn continuation_body(redirect: &CompleteAuthorizeRedirectResponse) -> serde_json::Value {
+        serde_json::to_value(build_continuation_request(
+            redirect,
+            Secret::new(CERT_STORE_AR.to_string()),
+        ))
+        .unwrap()
+    }
+
+    /// Igualdad EXACTA con el PATCH que cert aceptó en el paso del método
+    /// (evidencia.jsonl línea 24 — `3DS 3DSMethod Authenticated [methodNotificationStatus]`,
+    /// HTTP 200, apiTraceId anUDYSKQSojaSWQEaFJUFwAAA-E). Tres campos, ni uno más: `acsResponse`
+    /// no puede colarse en este paso.
+    #[test]
+    fn the_method_notification_patch_body_matches_the_one_cert_accepted() {
+        let con_notificacion = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: Some(Secret::new(serde_json::json!({
+                "threeDSMethodData": CERT_THREE_DS_METHOD_DATA,
+            }))),
+        };
+        assert_eq!(
+            continuation_body(&con_notificacion),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationUpdateRequest",
+                "storeId": CERT_STORE_AR,
+                "methodNotificationStatus": "RECEIVED",
+            })
+        );
+    }
+
+    /// El mismo paso cuando la notificación no llegó. Es el body que el conector manda SIEMPRE en
+    /// el flujo real (ver `the_received_status_is_unreachable_in_the_real_flow`), así que hace
+    /// falta saber que el gateway lo acepta: verificado en vivo sobre la tarjeta 3DSMethod del
+    /// checklist (4099000000001978) — HTTP 200, APPROVED, `responseCode3dSecure: 1`,
+    /// ipgTransactionId 84668171370, apiTraceId an0HXCR5qsxv6kPs1WraCAAAAcU. Y en
+    /// Challenge+Method (4265880000000064) el desafío igual llega después de este PATCH y el
+    /// `cRes` cierra en APPROVED (ipgTransactionId 84668171452, apiTraceId
+    /// an0Hq52Cn6oVn4oVRUS4qwAAAx8).
+    #[test]
+    fn the_expected_but_not_received_patch_body_is_accepted_by_cert() {
+        let sin_notificacion = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: None,
+        };
+        assert_eq!(
+            continuation_body(&sin_notificacion),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationUpdateRequest",
+                "storeId": CERT_STORE_AR,
+                "methodNotificationStatus": "EXPECTED_BUT_NOT_RECEIVED",
+            })
+        );
+    }
+
+    /// Igualdad EXACTA con el PATCH del `cRes` que cert aceptó (evidencia.jsonl línea 35, HTTP
+    /// 200, apiTraceId anUDkZEFKuhRjoXAr1V6TQAAANs). El mismo body, con un `cRes` obtenido en una
+    /// corrida propia, se aceptó de nuevo en vivo: ipgTransactionId 84668171391, apiTraceId
+    /// an0HbGYBclzAjybWpPC7TAAAA5w, APPROVED con `responseCode3dSecure: 1`.
+    #[test]
+    fn the_cres_patch_body_matches_the_one_cert_accepted() {
+        let con_cres = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: Some(Secret::new(
+                serde_json::json!({ "cRes": CERT_CRES_RESPONSE_1 }),
+            )),
+        };
+        assert_eq!(
+            continuation_body(&con_cres),
+            serde_json::json!({
+                "authenticationType": "Secure3D21AuthenticationUpdateRequest",
+                "storeId": CERT_STORE_AR,
+                "acsResponse": { "cRes": CERT_CRES_RESPONSE_1 },
+            })
+        );
+    }
+
+    /// GAP CONOCIDO, no un comportamiento deseado.
+    ///
+    /// `RECEIVED` es inalcanzable en el flujo real. `has_three_ds_method_data` mira el retorno
+    /// del navegador por la `termURL`, pero el `threeDSMethodData` nunca llega ahí: el ACS lo
+    /// publica en la `methodNotificationURL` —está escrito dentro del propio blob, campo
+    /// `threeDSMethodNotificationURL` (ver `CERT_THREE_DS_METHOD_DATA`)— y esa llamada el
+    /// conector la degrada a un PSync y la descarta. El retorno que sí manda el PATCH lo produce
+    /// `build_three_ds_method_wrapper` con un `window.location.replace(termURL)` pelado, sin
+    /// reenviar nada.
+    ///
+    /// Consecuencia: el conector le declara al emisor que el fingerprint del dispositivo falló
+    /// incluso cuando salió bien. En cert no cambia el resultado (los dos valores cierran en
+    /// APPROVED con `responseCode3dSecure: 1`), pero es un dato falso que en producción empuja al
+    /// emisor a pedir desafío donde correspondía frictionless.
+    #[test]
+    fn the_received_status_is_unreachable_in_the_real_flow() {
+        // 1. El wrapper navega a la termURL pelada: el destino no lleva ningún dato del método.
+        //    (El `threeDSMethodData` sí aparece dentro del `srcdoc`, que es el methodForm del
+        //    gateway hospedado en el iframe; lo que importa es que NO viaja en la navegación.)
+        let term_url =
+            build_three_ds_callback_url(THREE_DS_COMPLETE_AUTHORIZE_URL, "term").unwrap();
+        let wrapper = build_three_ds_method_wrapper(
+            "<form id=\"tdsMmethodForm\"><input name=\"threeDSMethodData\" value=\"x\"/></form>",
+            &term_url,
+        );
+        assert!(
+            wrapper.contains(&format!("var target = \"{term_url}\"")),
+            "el wrapper no navega a la termURL pelada: {wrapper}"
+        );
+        assert!(
+            !term_url.contains("threeDSMethodData"),
+            "el destino de la navegación lleva threeDSMethodData; el gap ya no existiría"
+        );
+
+        // 2. El retorno que llega, entonces, es sólo el marcador `term`.
+        let retorno_real = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: None,
+        };
+        assert!(!has_three_ds_method_data(&retorno_real));
+        assert_eq!(
+            build_continuation_request(&retorno_real, Secret::new(CERT_STORE_AR.to_string()))
+                .method_notification_status
+                .as_deref(),
+            Some("EXPECTED_BUT_NOT_RECEIVED"),
+            "si esto pasa a RECEIVED, el gap se cerró y hay que actualizar este test"
+        );
+
+        // 3. Y el callback que sí trae el dato es el del método, que no continúa nada.
+        let notificacion = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=method".to_string())),
+            payload: Some(Secret::new(serde_json::json!({
+                "threeDSMethodData": CERT_THREE_DS_METHOD_DATA,
+            }))),
+        };
+        assert!(has_three_ds_method_data(&notificacion));
+        assert!(is_acs_method_notification(&notificacion));
+    }
+
     // ---- Item 3: secure3dResponse.responseCode3dSecure is parsed, not dropped ----
 
     #[test]
@@ -2026,7 +3824,7 @@ mod tests {
                 month: Secret::new("12".to_string()),
                 year: Secret::new("30".to_string()),
             },
-            security_code: Secret::new("123".to_string()),
+            security_code: Some(Secret::new("123".to_string())),
             cardholder_name,
         }
     }
@@ -2075,7 +3873,7 @@ mod tests {
         let auth = response
             .authentication_response
             .expect("doc response carries an authenticationResponse");
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Html { html_data }) => {
                 assert_eq!(
                     html_data,
@@ -2115,7 +3913,7 @@ mod tests {
         let auth = response
             .authentication_response
             .expect("doc response carries an authenticationResponse");
-        match auth.to_redirection() {
+        match auth.to_redirection(None) {
             Some(RedirectForm::Form {
                 endpoint,
                 method,
@@ -2135,4 +3933,1559 @@ mod tests {
             other => panic!("expected Form redirect, got {other:?}"),
         }
     }
+
+    #[test]
+    fn error_response_deserializes_camel_case_fields() {
+        // Respuesta real del gateway cert ante un authenticationType inválido.
+        let raw = serde_json::json!({
+            "type": "errorResponse",
+            "clientRequestId": "a81ea7ae-078d-456f-a106-e8aa5a13ade2",
+            "apiTraceId": "anTLkyKQSojaSWQEaFJ6awAAA-M",
+            "responseType": "BadRequest",
+            "error": {
+                "code": "INVALID_INPUT",
+                "message": "Invalid request input. Please see details below."
+            }
+        });
+        let parsed: FiservemeaErrorResponse = serde_json::from_value(raw).unwrap();
+        assert_eq!(
+            parsed.client_request_id.as_deref(),
+            Some("a81ea7ae-078d-456f-a106-e8aa5a13ade2")
+        );
+        // El apiTraceId es el identificador con el que Fiserv busca en sus logs:
+        // antes se perdía porque el struct no declaraba camelCase.
+        assert_eq!(
+            parsed.api_trace_id.as_deref(),
+            Some("anTLkyKQSojaSWQEaFJ6awAAA-M")
+        );
+        assert_eq!(parsed.response_type.as_deref(), Some("BadRequest"));
+    }
+
+    #[test]
+    fn capture_method_none_is_auto_capture() {
+        // `None` significa automático en la API de Hyperswitch: tratarlo como manual
+        // mandaba un PreAuth y dejaba la retención sin capturar.
+        assert!(is_auto_capture(None));
+        assert!(is_auto_capture(Some(enums::CaptureMethod::Automatic)));
+        assert!(is_auto_capture(Some(enums::CaptureMethod::SequentialAutomatic)));
+        assert!(!is_auto_capture(Some(enums::CaptureMethod::Manual)));
+    }
+
+    #[test]
+    fn split_approval_code_parses_real_gateway_values() {
+        // Valores reales capturados contra cert.
+        assert_eq!(
+            split_approval_code(Some("N:-11101:installment not supported")),
+            (
+                Some("-11101".to_string()),
+                Some("installment not supported".to_string())
+            )
+        );
+        assert_eq!(
+            split_approval_code(Some("N:05:Do not honour")),
+            (Some("05".to_string()), Some("Do not honour".to_string()))
+        );
+        // El texto puede llevar ':' adentro y no debe partirse.
+        assert_eq!(
+            split_approval_code(Some("N:-50716:Transaction declined: 3D Secure")),
+            (
+                Some("-50716".to_string()),
+                Some("Transaction declined: 3D Secure".to_string())
+            )
+        );
+        // Formatos que no son `X:código:texto` no deben inventar un código.
+        assert_eq!(split_approval_code(Some("Y:683316")), (Some("683316".to_string()), None));
+        assert_eq!(split_approval_code(Some("")), (None, None));
+        assert_eq!(split_approval_code(None), (None, None));
+    }
+
+    /// Rechazo real del emisor traído del gateway de certificación (tienda AR, Mastercard
+    /// 5165850000000008, monto 1005 = "Do not honour" según la tabla de códigos DECLINED).
+    /// Llega con HTTP 422 y `responseType: EndpointDeclined`, o sea que lo procesa
+    /// `build_error_response`, no el `TryFrom` de `FiservemeaPaymentsResponse`.
+    fn real_cert_issuer_decline_422() -> serde_json::Value {
+        serde_json::json!({
+            "type": "TransactionErrorResponse",
+            "clientRequestId": "04e9f8af-56a6-4486-8292-6c3ad92f7742",
+            "apiTraceId": "anX00xdinKHsuo_YUYCS7QAAA40",
+            "responseType": "EndpointDeclined",
+            "ipgTransactionId": "84667456653",
+            "orderId": "PX-1786115282-01-gap5",
+            "transactionType": "SALE",
+            "transactionStatus": "DECLINED",
+            "transactionResult": "DECLINED",
+            "approvalCode": "N:05:Do not honour",
+            "errorMessage": "50005: Do not honour",
+            "transactionState": "DECLINED",
+            "processor": {
+                "referenceNumber": "000000024168",
+                "authorizationCode": "82333",
+                "responseCode": "05",
+                "responseMessage": "Do not honour",
+                "avsResponse": {
+                    "streetMatch": "NO_INPUT_DATA",
+                    "postalCodeMatch": "NO_INPUT_DATA"
+                },
+                "securityCodeResponse": "NOT_CHECKED",
+                "taxRefundData": {}
+            },
+            "error": { "code": "50005", "message": "Do not honour" }
+        })
+    }
+
+    #[test]
+    fn issuer_decline_error_response_parses_processor_block() {
+        // El camino real de un rechazo del emisor es el HTTP 422, así que
+        // `FiservemeaErrorResponse` tiene que quedarse con el `processor`: sin eso los códigos
+        // de red se perdían en el único flujo donde efectivamente llegan.
+        let parsed: FiservemeaErrorResponse =
+            serde_json::from_value(real_cert_issuer_decline_422()).unwrap();
+        assert_eq!(parsed.response_type.as_deref(), Some("EndpointDeclined"));
+
+        let network = FiservemeaNetworkCodes::from_processor(parsed.processor.as_ref());
+        assert_eq!(
+            network,
+            FiservemeaNetworkCodes {
+                // Cert no manda `associationResponseCode`; el fallback al `responseCode` ISO
+                // evita que el motor de reintentos se quede sin ningún código.
+                decline_code: Some("05".to_string()),
+                advice_code: None,
+                error_message: Some("Do not honour".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn network_codes_use_the_iso_response_code_and_expose_merchant_advice_code() {
+        // Bloque `processor` tal cual lo publica el Manual NetworkToken MTRG en su forma REST:
+        // es el único documento de Fiserv que muestra `associationResponseCode`, y lo muestra
+        // con el valor `"XX"` en una transacción APROBADA. Ese fixture es justamente el motivo
+        // para no preferirlo: publicar `"XX"` como código de rechazo de red le daría al motor
+        // de reintentos un valor que no es un código ISO.
+        let processor: Processor = serde_json::from_value(serde_json::json!({
+            "referenceNumber": "908651908651",
+            "authorizationCode": "908651",
+            "responseCode": "00",
+            "associationResponseCode": "XX",
+            "responseMessage": "Function performed error-free",
+            "avsResponse": {
+                "streetMatch": "NO_INPUT_DATA",
+                "postalCodeMatch": "NO_INPUT_DATA"
+            },
+            "securityCodeResponse": "NOT_CHECKED",
+            "merchantAdviceCodeIndicator": "01",
+            "taxRefundData": {}
+        }))
+        .unwrap();
+
+        let network = FiservemeaNetworkCodes::from_processor(Some(&processor));
+        assert_eq!(
+            network,
+            FiservemeaNetworkCodes {
+                // El ISO del procesador, que es el único campo que vimos llevando códigos
+                // reales (01, 05, 51…) en las respuestas del gateway de certificación.
+                decline_code: Some("00".to_string()),
+                // El MAC de Mastercard es lo que decide si reintentar tiene penalidad.
+                advice_code: Some("01".to_string()),
+                error_message: Some("Function performed error-free".to_string()),
+            }
+        );
+        // `associationResponseCode` se sigue parseando: si más adelante se confirma qué publica
+        // en un rechazo real, el campo ya está disponible sin volver a tocar el struct.
+        assert_eq!(processor.association_response_code.as_deref(), Some("XX"));
+    }
+
+    #[test]
+    fn network_codes_are_empty_without_processor_block() {
+        // Los rechazos de validación del gateway (HTTP 409 `GatewayDeclined`, p. ej.
+        // `N:-11101:installment not supported`) no traen `processor`: no hay código de red que
+        // publicar y no hay que fabricarlo con el del gateway.
+        assert_eq!(
+            FiservemeaNetworkCodes::from_processor(None),
+            FiservemeaNetworkCodes::default()
+        );
+    }
+
+    #[test]
+    fn merchant_transaction_id_is_truncated_to_gateway_limit() {
+        // IPG corta en 40; merchant_order_reference_id acepta hasta 255.
+        let largo = "PXSOL-RESERVA-2026-08-06-HOTEL-1234-HABITACION-501-CONFIRMADA";
+        let truncado: String = largo
+            .chars()
+            .take(FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN)
+            .collect();
+        assert_eq!(truncado.chars().count(), 40);
+        assert!(largo.starts_with(&truncado));
+    }
+
+    /// Venta APROBADA real del gateway de cert (POST /payments, HTTP 200). Se usa como base
+    /// de los casos de valor desconocido: lo importante es que ninguna mutación puntual de un
+    /// enum convierta este cobro en un error de deserialización.
+    fn real_cert_approved_sale() -> serde_json::Value {
+        serde_json::json!({
+            "type": "transactionResponse",
+            "clientRequestId": "d0479c7c-ed0b-4628-86f4-5d9cdee57a30",
+            "apiTraceId": "anUDKXbyIFesn-w_H27JzQAAA9E",
+            "ipgTransactionId": "84667286258",
+            "orderId": "PX-1786053416-01-sale",
+            "transactionType": "SALE",
+            "transactionOrigin": "ECOM",
+            "paymentMethodDetails": {
+                "paymentCard": {
+                    "expiryDate": { "month": "12", "year": "2029" },
+                    "bin": "516585", "last4": "0008", "brand": "MASTERCARD"
+                },
+                "paymentMethodType": "PAYMENT_CARD",
+                "paymentMethodBrand": "MASTERCARD"
+            },
+            "country": "Argentina",
+            "terminalId": "98000002",
+            "merchantId": "00000014",
+            "merchantTransactionId": "PX-1786053416-01-sale",
+            "transactionTime": 1_786_053_417_i64,
+            "approvedAmount": { "total": 1000.0, "currency": "ARS", "components": { "subtotal": 1000.0 } },
+            "transactionAmount": { "total": 1000.0, "currency": "ARS", "components": { "subtotal": 1000.0 } },
+            "transactionStatus": "APPROVED",
+            "transactionResult": "APPROVED",
+            "approvalCode": "Y:943616:4667286258:PPXX:9476656675",
+            "transactionState": "CAPTURED",
+            "processor": {
+                "referenceNumber": "000000019357",
+                "authorizationCode": "943616",
+                "responseCode": "00",
+                "responseMessage": "Function performed error-free"
+            }
+        })
+    }
+
+    fn parse_response(raw: serde_json::Value) -> FiservemeaPaymentsResponse {
+        serde_json::from_value(raw).expect("la respuesta del gateway debe deserializar")
+    }
+
+    fn status_of(response: FiservemeaPaymentsResponse) -> common_enums::AttemptStatus {
+        map_status(
+            response.transaction_status,
+            response.transaction_result,
+            response.transaction_type,
+            response.transaction_state.as_deref(),
+        )
+    }
+
+    #[test]
+    fn real_cert_approved_sale_still_maps_to_charged() {
+        // Línea de base: el caso feliz no cambia de significado por el fallback.
+        assert_eq!(
+            status_of(parse_response(real_cert_approved_sale())),
+            common_enums::AttemptStatus::Charged
+        );
+    }
+
+    #[test]
+    fn unknown_transaction_type_parses_and_does_not_claim_charged() {
+        // Mismo cobro real, con un `transactionType` que el conector no contempla. Antes esto
+        // no deserializaba y el cobro se reportaba como error de conector.
+        let mut raw = real_cert_approved_sale();
+        raw["transactionType"] = serde_json::json!("SPLIT_SHIPMENT");
+        let response = parse_response(raw);
+        assert_eq!(
+            response.transaction_type,
+            Some(FiservemeaTransactionType::Unknown)
+        );
+        // Aprobado pero sin saber si autorizó, capturó o anuló: ni Charged ni Failure.
+        assert_eq!(
+            status_of(response),
+            common_enums::AttemptStatus::Pending,
+            "un tipo desconocido no puede dar el cobro por bueno ni por perdido"
+        );
+    }
+
+    #[test]
+    fn missing_transaction_type_parses_and_stays_pending() {
+        // El gateway devuelve respuestas sin `transactionType` (ver el rechazo real
+        // "Unable to verify card enrollment"), así que el campo no puede ser obligatorio.
+        let mut raw = real_cert_approved_sale();
+        raw.as_object_mut().unwrap().remove("transactionType");
+        let response = parse_response(raw);
+        assert!(response.transaction_type.is_none());
+        assert_eq!(status_of(response), common_enums::AttemptStatus::Pending);
+    }
+
+    #[test]
+    fn unknown_transaction_status_falls_back_to_transaction_result() {
+        // `transactionStatus` está deprecado: si trae un valor nuevo no debe tapar al
+        // `transactionResult` vigente, que en esta misma respuesta real dice APPROVED.
+        let mut raw = real_cert_approved_sale();
+        raw["transactionStatus"] = serde_json::json!("SETTLED");
+        let response = parse_response(raw);
+        assert_eq!(
+            response.transaction_status,
+            Some(FiservemeaPaymentStatus::Unknown)
+        );
+        assert_eq!(status_of(response), common_enums::AttemptStatus::Charged);
+    }
+
+    #[test]
+    fn unknown_transaction_result_keeps_attempt_pending() {
+        // Sin ningún campo interpretable no se puede decidir: queda para el PSync.
+        let mut raw = real_cert_approved_sale();
+        raw.as_object_mut().unwrap().remove("transactionStatus");
+        raw["transactionResult"] = serde_json::json!("REVIEW");
+        let response = parse_response(raw);
+        assert_eq!(
+            response.transaction_result,
+            Some(FiservemeaPaymentResult::Unknown)
+        );
+        assert_eq!(status_of(response), common_enums::AttemptStatus::Pending);
+    }
+
+    #[test]
+    fn unknown_transaction_origin_and_response_type_do_not_break_parsing() {
+        // Estos dos enums no deciden el estado, pero al ser campos de la misma struct un
+        // valor nuevo en cualquiera de ellos hacía fallar el parseo de todo el cobro.
+        let mut raw = real_cert_approved_sale();
+        raw["transactionOrigin"] = serde_json::json!("IN_APP");
+        raw["responseType"] = serde_json::json!("SomethingNew");
+        assert_eq!(
+            status_of(parse_response(raw)),
+            common_enums::AttemptStatus::Charged
+        );
+    }
+
+    #[test]
+    fn real_cert_decline_without_ids_deserializes() {
+        // Rechazo real (HTTP 409) del caso 3DS Data Only: llega sin `ipgTransactionId` y sin
+        // `transactionType`. Con esos campos obligatorios la respuesta no parseaba y se perdía
+        // hasta el motivo del rechazo.
+        let raw = serde_json::json!({
+            "type": "TransactionErrorResponse",
+            "clientRequestId": "496db1e7-352f-46ea-9946-3b1c8c57d2ea",
+            "apiTraceId": "anUD4RdinKHsuo_YUYCCjQAAA5M",
+            "responseType": "GatewayDeclined",
+            "orderId": "PX-1786053599-33-3ds-dataonly",
+            "transactionTime": 1_786_053_601_i64,
+            "transactionStatus": "VALIDATION_FAILED",
+            "transactionResult": "FAILED",
+            "approvalCode": "N:-50655:Unable to verify card enrollment",
+            "errorMessage": "50655: Unable to verify card enrollment",
+            "secure3dResponse": { "responseCode3dSecure": "8" }
+        });
+        let response = parse_response(raw);
+        assert!(response.ipg_transaction_id.is_none());
+        assert!(response.transaction_type.is_none());
+        assert_eq!(status_of(response), common_enums::AttemptStatus::Failure);
+    }
+
+    #[test]
+    fn real_cert_declined_sale_maps_to_failure() {
+        // Rechazo real de cuotas con tarjeta no local (HTTP 409): VALIDATION_FAILED/FAILED
+        // debe seguir siendo Failure después de reordenar `map_status`.
+        let raw = serde_json::json!({
+            "type": "TransactionErrorResponse",
+            "responseType": "GatewayDeclined",
+            "ipgTransactionId": "84667286314",
+            "orderId": "PX-1786053442-11-mtrg",
+            "transactionType": "SALE",
+            "transactionStatus": "VALIDATION_FAILED",
+            "transactionResult": "FAILED",
+            "approvalCode": "N:-11101:installment not supported",
+            "errorMessage": "11101: installment only supported for local cards",
+            "transactionState": "DECLINED"
+        });
+        assert_eq!(
+            status_of(parse_response(raw)),
+            common_enums::AttemptStatus::Failure
+        );
+    }
+
+    #[test]
+    fn real_cert_void_maps_to_voided() {
+        // Anulación real: APPROVED + transactionType VOID.
+        let raw = serde_json::json!({
+            "type": "transactionResponse",
+            "ipgTransactionId": "84667286297",
+            "orderId": "PX-1786053427-07-void",
+            "transactionType": "VOID",
+            "transactionStatus": "APPROVED",
+            "transactionResult": "APPROVED",
+            "approvalCode": "Y:470405:4667286297:PPXX:9476816680",
+            "transactionState": "VOIDED"
+        });
+        assert_eq!(
+            status_of(parse_response(raw)),
+            common_enums::AttemptStatus::Voided
+        );
+    }
+
+    #[test]
+    fn real_cert_waiting_3ds_maps_to_pending() {
+        // Primer paso 3DS real: WAITING en los dos campos mientras corre el 3DSMethod.
+        let raw = serde_json::json!({
+            "type": "transactionResponse",
+            "ipgTransactionId": "84667286332",
+            "orderId": "PX-1786053463-18-3ds-mth-y",
+            "transactionType": "SALE",
+            "transactionStatus": "WAITING",
+            "transactionResult": "WAITING",
+            "approvalCode": "?:waiting 3dsecureMethod",
+            "transactionState": "WAITING"
+        });
+        assert_eq!(
+            status_of(parse_response(raw)),
+            common_enums::AttemptStatus::Pending
+        );
+    }
+
+    /// Devolución total real del gateway de cert (POST /payments/{id}).
+    fn real_cert_return() -> serde_json::Value {
+        serde_json::json!({
+            "type": "transactionResponse",
+            "ipgTransactionId": "84667286299",
+            "orderId": "PX-1786053430-08-rettot",
+            "transactionType": "RETURN",
+            "transactionOrigin": "ECOM",
+            "transactionTime": 1_786_053_434_i64,
+            "approvedAmount": { "total": 1000.0, "currency": "ARS", "components": { "subtotal": 1000.0 } },
+            "transactionAmount": { "total": 1000.0, "currency": "ARS", "components": { "subtotal": 1000.0 } },
+            "transactionStatus": "APPROVED",
+            "transactionResult": "APPROVED",
+            "approvalCode": "Y:954253:4667286299:PPXX:9476858437",
+            "transactionState": "CAPTURED"
+        })
+    }
+
+    #[test]
+    fn real_cert_return_maps_refund_to_success() {
+        let response = parse_response(real_cert_return());
+        assert_eq!(
+            map_refund_status(response.transaction_status, response.transaction_result),
+            enums::RefundStatus::Success
+        );
+    }
+
+    #[test]
+    fn unknown_refund_result_stays_pending_instead_of_failing() {
+        // El `RETURN` ya viajó al gateway. Un desenlace que no sabemos leer no puede quedar
+        // como Failure/error, porque eso habilita reintentar y pagarle dos veces al cliente.
+        let mut raw = real_cert_return();
+        raw["transactionStatus"] = serde_json::json!("SETTLED");
+        raw["transactionResult"] = serde_json::json!("REVIEW");
+        let response = parse_response(raw);
+        assert_eq!(
+            map_refund_status(response.transaction_status, response.transaction_result),
+            enums::RefundStatus::Pending
+        );
+    }
+
+    #[test]
+    fn unknown_refund_status_falls_back_to_refund_result() {
+        let mut raw = real_cert_return();
+        raw["transactionStatus"] = serde_json::json!("SETTLED");
+        let response = parse_response(raw);
+        assert_eq!(
+            map_refund_status(response.transaction_status, response.transaction_result),
+            enums::RefundStatus::Success
+        );
+    }
+
+    #[test]
+    fn refund_without_any_outcome_field_stays_pending() {
+        // Antes esto era `Err(MissingRequiredField)`: mismo riesgo de doble devolución.
+        let mut raw = real_cert_return();
+        let object = raw.as_object_mut().unwrap();
+        object.remove("transactionStatus");
+        object.remove("transactionResult");
+        let response = parse_response(raw);
+        assert_eq!(
+            map_refund_status(response.transaction_status, response.transaction_result),
+            enums::RefundStatus::Pending
+        );
+    }
+    /// `methodForm` real del gateway de certificación (respuesta del POST /payments del caso
+    /// "3DSMethod Authenticated"), recortado a lo estructural: el iframe oculto y el form que
+    /// apunta a ese mismo iframe.
+    const CERT_METHOD_FORM: &str = r#"<iframe id="tdsMmethodTgtFrame" name="tdsMmethodTgtFrame" style="visibility: hidden; width: 1px; height: 1px;"></iframe><form id="tdsMmethodForm" name="tdsMmethodForm" action="https://3ds-acs.test.modirum.com/mdpayacs/3ds-method" method="post" target="tdsMmethodTgtFrame"><input type="hidden" name="threeDSMethodData" value="eyAidGhyZWVEU1Nl"/></form>"#;
+
+    #[test]
+    fn cert_method_form_cannot_continue_the_flow_on_its_own() {
+        // Es el diagnóstico que justifica el wrapper: el form del gateway apunta su `target` al
+        // iframe oculto y no toca la ventana principal, así que lo que venga después del
+        // fingerprint se renderiza invisible.
+        assert!(CERT_METHOD_FORM.contains("visibility: hidden"));
+        assert!(CERT_METHOD_FORM.contains(r#"target="tdsMmethodTgtFrame""#));
+        assert!(!CERT_METHOD_FORM.contains("window.top"));
+        assert!(!CERT_METHOD_FORM.contains("location"));
+    }
+
+    #[test]
+    fn method_form_wrapper_hosts_the_form_and_navigates_the_main_window() {
+        let wrapper = build_three_ds_method_wrapper(CERT_METHOD_FORM, TEST_RETURN_URL);
+
+        // El form viaja escapado dentro del `srcdoc`, no suelto en la página: si se inyectara
+        // crudo, su `</form>` cerraría el marcado del wrapper.
+        assert!(wrapper.contains("srcdoc=\""));
+        assert!(!wrapper.contains(r#"<form id="tdsMmethodForm""#));
+        assert!(wrapper.contains("&lt;form id=&quot;tdsMmethodForm&quot;"));
+        // Pero el fingerprint del emisor tiene que seguir ejecutándose.
+        assert!(wrapper.contains("https://3ds-acs.test.modirum.com/mdpayacs/3ds-method"));
+
+        // La espera mínima que exige la guía, y la navegación de la ventana principal.
+        assert!(wrapper.contains("window.setTimeout(continueAuthentication, 10000)"));
+        assert!(wrapper.contains(TEST_RETURN_URL));
+        // Y la guarda que evita un retorno duplicado si esta misma página quedara anidada.
+        assert!(wrapper.contains("window.self !== window.top"));
+    }
+
+    #[test]
+    fn method_form_wrapper_escapes_a_hostile_return_url() {
+        // La URL de retorno es configuración del comercio: no puede cerrar el `<script>`.
+        let wrapper = build_three_ds_method_wrapper(
+            CERT_METHOD_FORM,
+            r#"https://x.test/r?a="</script><script>alert(1)</script>"#,
+        );
+        assert!(!wrapper.contains("</script><script>alert(1)"));
+        assert!(wrapper.contains("\\u003c/script"));
+    }
+
+    #[test]
+    fn method_form_redirection_is_wrapped_only_when_the_return_url_is_known() {
+        let auth: FiservemeaAuthenticationResponse = serde_json::from_value(serde_json::json!({
+            "type": "3D_SECURE",
+            "version": "2.2",
+            "secure3dMethod": { "methodForm": CERT_METHOD_FORM }
+        }))
+        .unwrap();
+
+        match auth.to_redirection(Some(TEST_RETURN_URL)) {
+            Some(RedirectForm::Html { html_data }) => {
+                assert!(html_data.contains("window.setTimeout(continueAuthentication"))
+            }
+            other => panic!("se esperaba el wrapper, salió {other:?}"),
+        }
+        // Sin URL de retorno se devuelve el form crudo: es el comportamiento anterior, peor pero
+        // no una regresión respecto de no responder nada.
+        match auth.to_redirection(None) {
+            Some(RedirectForm::Html { html_data }) => assert_eq!(html_data, CERT_METHOD_FORM),
+            other => panic!("se esperaba el form crudo, salió {other:?}"),
+        }
+    }
+
+    #[test]
+    fn network_token_pairing_only_when_the_gateway_substituted() {
+        // Venta MTRG real por el flujo OnTheGo: el gateway procesó con Network Token, así que el
+        // BIN procesado (432312) difiere del que fondea (462294). Es el emparejamiento que el
+        // manual de Network Token exige guardar en cada transacción aprobada.
+        let details: FiservemeaPaymentMethodDetails = serde_json::from_value(serde_json::json!({
+            "paymentCard": {
+                "expiryDate": { "month": "12", "year": "2029" },
+                "fundingCardNumber": { "bin": "462294", "last4": "2366" },
+                "bin": "432312",
+                "last4": "7867",
+                "brand": "VISA"
+            },
+            "paymentMethodType": "PAYMENT_CARD",
+            "paymentMethodBrand": "VISA"
+        }))
+        .unwrap();
+        assert_eq!(
+            details.network_token_pairing(),
+            Some(FiservemeaNetworkTokenPairing {
+                network_token_bin: "432312".to_string(),
+                network_token_last4: "7867".to_string(),
+                funding_card_bin: "462294".to_string(),
+                funding_card_last4: "2366".to_string(),
+            })
+        );
+
+        // Venta común sin tokenización de marca: IPG manda `fundingCardNumber` igual, con el
+        // MISMO bin. Emitir el emparejamiento acá afirmaría una tokenización que no ocurrió.
+        let details: FiservemeaPaymentMethodDetails = serde_json::from_value(serde_json::json!({
+            "paymentCard": {
+                "fundingCardNumber": { "bin": "516585", "last4": "0008" },
+                "bin": "516585",
+                "last4": "0008",
+                "brand": "MASTERCARD"
+            }
+        }))
+        .unwrap();
+        assert_eq!(details.network_token_pairing(), None);
+    }
+
+    #[test]
+    fn stored_credentials_follow_the_vendor_examples_per_brand() {
+        // Visa FIRST: la guía NO manda el bloque; alcanza `recurringType: FIRST`.
+        assert_eq!(FiservemeaStoredCredentials::new(false, true, None), None);
+
+        // Visa REPEAT: sólo transporta el `referencedSchemeTransactionId`, sin initiator ni
+        // indicatorSubcategory (guía §11.3.1.1.b).
+        assert_eq!(
+            FiservemeaStoredCredentials::new(false, false, Some("098765432112345".to_string())),
+            Some(FiservemeaStoredCredentials {
+                sequence: FiservemeaStoredCredentialSequence::Subsequent,
+                scheduled: false,
+                initiator: None,
+                indicator_subcategory: None,
+                referenced_scheme_transaction_id: Some("098765432112345".to_string()),
+            })
+        );
+        // Y sin ese id no hay nada que informar.
+        assert_eq!(FiservemeaStoredCredentials::new(false, false, None), None);
+
+        // Mastercard FIRST y SUBSEQUENT: los dos con MERCHANT + CREDENTIAL_ON_FILE_FIRST. El
+        // ejemplo de la guía repite esa subcategoría también en la SUBSEQUENT (§11.3.1.2.b).
+        for (is_first, esperado) in [
+            (true, FiservemeaStoredCredentialSequence::First),
+            (false, FiservemeaStoredCredentialSequence::Subsequent),
+        ] {
+            let sc = FiservemeaStoredCredentials::new(true, is_first, None).unwrap();
+            assert_eq!(sc.sequence, esperado);
+            assert_eq!(
+                sc.initiator,
+                Some(FiservemeaStoredCredentialInitiator::Merchant)
+            );
+            assert_eq!(
+                sc.indicator_subcategory,
+                Some(FISERVEMEA_INDICATOR_CREDENTIAL_ON_FILE_FIRST)
+            );
+        }
+    }
+
+    #[test]
+    fn stored_credentials_serialize_like_the_vendor_example() {
+        // Comparación del objeto completo contra el ejemplo Mastercard FIRST de la guía, para
+        // que un campo nuevo no se cuele sin que un test lo note.
+        let sc = FiservemeaStoredCredentials::new(true, true, None).unwrap();
+        assert_eq!(
+            serde_json::to_value(&sc).unwrap(),
+            serde_json::json!({
+                "sequence": "FIRST",
+                "scheduled": false,
+                "initiator": "MERCHANT",
+                "indicatorSubcategory": "CREDENTIAL_ON_FILE_FIRST"
+            })
+        );
+    }
+
+    #[test]
+    fn installment_options_carry_recurring_type_without_inventing_installments() {
+        // Los ejemplos de recurrencia mandan `installmentOptions` con SÓLO `recurringType`:
+        // serializar un `numberOfInstallments: 0` ahí sería inventar un plan de cuotas.
+        let options = FiservemeaInstallmentOptions {
+            number_of_installments: None,
+            interest: None,
+            recurring_type: Some(FiservemeaRecurringType::First),
+        };
+        assert_eq!(
+            serde_json::to_value(&options).unwrap(),
+            serde_json::json!({ "recurringType": "FIRST" })
+        );
+    }
+
+    #[test]
+    fn interest_is_not_emitted_without_an_installment_plan() {
+        // `Interest` sin `numberOfInstallments` sería un campo sin referente: la guía sólo lo
+        // documenta acompañando un plan de cuotas.
+        let options = FiservemeaInstallmentOptions {
+            number_of_installments: None,
+            interest: None,
+            recurring_type: Some(FiservemeaRecurringType::Repeat),
+        };
+        let json = serde_json::to_value(&options).unwrap();
+        assert!(json.get("Interest").is_none());
+        assert!(json.get("numberOfInstallments").is_none());
+        assert_eq!(json["recurringType"], "REPEAT");
+    }
+
+    #[test]
+    fn token_cryptogram_length_is_measured_in_characters() {
+        // El gateway valida el largo entre 20 y 256 (verificado contra cert: "ZZZZ" devuelve
+        // `order.tokenCryptogram: size must be between 20 and 256`). El criptograma real es
+        // base64, o sea ASCII, pero medir en caracteres y no en bytes evita que un valor con
+        // multibyte pase o falle por el motivo equivocado.
+        let ejemplo = "AgAAAAoAPlUosiUEDQNSgElQEAA=";
+        assert_eq!(ejemplo.chars().count(), 28);
+        assert!(FISERVEMEA_TOKEN_CRYPTOGRAM_LEN.contains(&ejemplo.chars().count()));
+        assert!(!FISERVEMEA_TOKEN_CRYPTOGRAM_LEN.contains(&"ZZZZ".chars().count()));
+        // 20 caracteres multibyte son 40+ bytes: medido en bytes esto pasaría el mínimo por el
+        // motivo equivocado.
+        let multibyte: String = "ñ".repeat(20);
+        assert_eq!(multibyte.chars().count(), 20);
+        assert!(multibyte.len() > 20);
+        assert!(FISERVEMEA_TOKEN_CRYPTOGRAM_LEN.contains(&multibyte.chars().count()));
+    }
+
+    #[test]
+    fn the_two_three_ds_callbacks_are_distinguishable() {
+        let term = build_three_ds_callback_url(TEST_RETURN_URL, THREE_DS_CALLBACK_TERM).unwrap();
+        let method =
+            build_three_ds_callback_url(TEST_RETURN_URL, THREE_DS_CALLBACK_METHOD).unwrap();
+        assert_ne!(term, method);
+        assert!(term.contains("fiservemea3ds=term"));
+        assert!(method.contains("fiservemea3ds=method"));
+
+        // Un complete_authorize_url que ya trae query string no se rompe.
+        let con_query =
+            build_three_ds_callback_url("https://x.test/r?pago=abc", THREE_DS_CALLBACK_METHOD)
+                .unwrap();
+        assert!(con_query.contains("pago=abc"));
+        assert!(con_query.contains("fiservemea3ds=method"));
+
+        // Y una URL inválida falla cerrado en vez de mandarle basura al ACS.
+        assert!(build_three_ds_callback_url("no-es-una-url", THREE_DS_CALLBACK_TERM).is_err());
+    }
+
+    #[test]
+    fn authentication_request_sends_the_two_urls_apart() {
+        // Es la corrección de fondo del 3DS: si las dos URLs son la misma, la notificación que el
+        // ACS publica dentro del iframe oculto dispara la continuación y el desafío se renderiza
+        // invisible. Separándolas, la continuación la manda el retorno por la termURL, que ocurre
+        // en la ventana principal.
+        let meta = meta_from_json(serde_json::json!({}));
+        let request = FiservemeaAuthenticationRequest::new(
+            build_three_ds_callback_url(TEST_RETURN_URL, THREE_DS_CALLBACK_TERM).unwrap(),
+            build_three_ds_callback_url(TEST_RETURN_URL, THREE_DS_CALLBACK_METHOD).unwrap(),
+            &meta,
+            false,
+        )
+        .unwrap();
+        let json = serde_json::to_value(&request).unwrap();
+        assert_ne!(json["termURL"], json["methodNotificationURL"]);
+        assert!(json["termURL"].as_str().unwrap().contains("=term"));
+        assert!(json["methodNotificationURL"]
+            .as_str()
+            .unwrap()
+            .contains("=method"));
+    }
+
+    #[test]
+    fn acs_method_notification_is_told_apart_from_the_browser_return() {
+        // El POST del ACS a la methodNotificationURL: NO debe continuar la autenticación.
+        let acs = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new(
+                "fiservemea3ds=method&threeDSMethodData=eyJ0aHJlZURTU2Vy".to_string(),
+            )),
+            payload: None,
+        };
+        assert!(is_acs_method_notification(&acs));
+
+        // El retorno del navegador por la termURL: es el que lleva el PATCH.
+        let browser = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("fiservemea3ds=term".to_string())),
+            payload: None,
+        };
+        assert!(!is_acs_method_notification(&browser));
+
+        // También se acepta el marcador en el payload JSON, porque el ACS publica de las dos
+        // formas.
+        let acs_json = CompleteAuthorizeRedirectResponse {
+            params: None,
+            payload: Some(Secret::new(
+                serde_json::json!({ "fiservemea3ds": "method" }),
+            )),
+        };
+        assert!(is_acs_method_notification(&acs_json));
+
+        // Sin marcador se trata como retorno del navegador: es el comportamiento anterior, para
+        // las transacciones iniciadas antes de este cambio.
+        let sin_marcador = CompleteAuthorizeRedirectResponse {
+            params: Some(Secret::new("cres=abc".to_string())),
+            payload: None,
+        };
+        assert!(!is_acs_method_notification(&sin_marcador));
+    }
+
+    #[test]
+    fn wrapper_navigates_to_the_term_callback_not_the_method_one() {
+        // Si el wrapper navegara a la methodNotificationURL, el retorno visible se degradaría a
+        // una consulta y el desafío no se mostraría nunca.
+        let term = build_three_ds_callback_url(TEST_RETURN_URL, THREE_DS_CALLBACK_TERM).unwrap();
+        let wrapper = build_three_ds_method_wrapper(CERT_METHOD_FORM, &term);
+        assert!(wrapper.contains("fiservemea3ds=term"));
+        assert!(!wrapper.contains("fiservemea3ds=method"));
+    }
+
+    // =================================================================================
+    // CONTRASTE CONTRA LOS PAYLOADS REALES DEL GATEWAY DE CERTIFICACIÓN
+    //
+    // Cada `expected` de acá abajo es, copiado tal cual, el `request` que el harness de
+    // homologación mandó y que el gateway respondió con HTTP 200. Fuente:
+    //   fiserv_homologacion_logs/20260806-215656/evidencia.jsonl
+    // (una línea por caso; el índice de la línea va citado en cada test).
+    //
+    // Los tests construyen el request POR EL CAMINO REAL del conector — el mismo `TryFrom`
+    // que usa `get_request_body`, con la misma conversión de importe
+    // (`StringMajorUnitForConnector`) — y comparan el JSON completo contra el que el gateway
+    // ya aceptó. Cualquier diferencia de nombre de campo, de tipo (string vs número) o de
+    // anidamiento hace fallar el test.
+    // =================================================================================
+
+    use std::marker::PhantomData;
+
+    use common_utils::types::{AmountConvertor, MinorUnit, StringMajorUnitForConnector};
+    use hyperswitch_domain_models::{
+        payment_address::PaymentAddress,
+        payment_method_data::Card,
+        router_request_types::{
+            PaymentMethodTokenizationData, PaymentsAuthorizeData, PaymentsCancelData,
+            PaymentsCaptureData, RefundsData,
+        },
+    };
+
+    /// Tienda AR del checklist.
+    const CERT_STORE_AR: &str = "5926072901";
+    /// Tienda con TOKEN GW habilitado.
+    const CERT_STORE_TOKEN_GW: &str = "5926072902";
+    /// Mastercard de pruebas de la homologación.
+    const CERT_CARD: &str = "5165850000000008";
+    /// Visa que el gateway sustituye por Network Token (flujo MTRG OnTheGo).
+    const CERT_CARD_MTRG: &str = "4622943127032366";
+
+    fn cert_auth(store_id: &str) -> ConnectorAuthType {
+        ConnectorAuthType::SignatureKey {
+            api_key: Secret::new("apikey".to_string()),
+            key1: Secret::new(store_id.to_string()),
+            api_secret: Secret::new("apisecret".to_string()),
+        }
+    }
+
+    /// Tarjeta con el vencimiento 12/2029 que usó la homologación (el conector lo recorta a
+    /// dos dígitos, igual que el harness).
+    fn cert_card_data(number: &str) -> PaymentMethodData {
+        PaymentMethodData::Card(Card {
+            card_number: number.parse().unwrap(),
+            card_exp_month: Secret::new("12".to_string()),
+            card_exp_year: Secret::new("2029".to_string()),
+            card_cvc: Secret::new("123".to_string()),
+            ..Default::default()
+        })
+    }
+
+    /// `RouterData` mínimo pero completo: sólo se llenan los campos que el conector lee.
+    fn cert_router_data<Flow, Req, Res>(
+        store_id: &str,
+        reference_id: &str,
+        request: Req,
+    ) -> RouterData<Flow, Req, Res> {
+        RouterData {
+            flow: PhantomData,
+            merchant_id: common_utils::id_type::MerchantId::default(),
+            customer_id: None,
+            connector_customer: None,
+            connector: "fiservemea".to_string(),
+            payment_id: reference_id.to_string(),
+            attempt_id: reference_id.to_string(),
+            tenant_id: common_utils::id_type::TenantId::try_from_string("public".to_string())
+                .unwrap(),
+            status: common_enums::AttemptStatus::Pending,
+            payment_method: common_enums::PaymentMethod::Card,
+            connector_auth_type: cert_auth(store_id),
+            description: None,
+            address: PaymentAddress::default(),
+            auth_type: common_enums::AuthenticationType::NoThreeDs,
+            connector_meta_data: None,
+            connector_wallets_details: None,
+            amount_captured: None,
+            access_token: None,
+            session_token: None,
+            reference_id: None,
+            payment_method_token: None,
+            recurring_mandate_payment_data: None,
+            preprocessing_id: None,
+            payment_method_balance: None,
+            connector_api_version: None,
+            request,
+            response: Err(ErrorResponse::default()),
+            connector_request_reference_id: reference_id.to_string(),
+            #[cfg(feature = "payouts")]
+            payout_method_data: None,
+            #[cfg(feature = "payouts")]
+            quote_id: None,
+            test_mode: Some(true),
+            connector_http_status_code: None,
+            external_latency: None,
+            apple_pay_flow: None,
+            frm_metadata: None,
+            dispute_id: None,
+            refund_id: None,
+            connector_response: None,
+            payment_method_status: None,
+            minor_amount_captured: None,
+            minor_amount_capturable: None,
+            integrity_check: Ok(()),
+            additional_merchant_data: None,
+            header_payload: None,
+            connector_mandate_request_reference_id: None,
+            l2_l3_data: None,
+            authentication_id: None,
+            psd2_sca_exemption_type: None,
+            raw_connector_response: None,
+            is_payment_id_from_merchant: None,
+        }
+    }
+
+    fn cert_authorize_data(
+        payment_method_data: PaymentMethodData,
+        minor_amount: i64,
+        currency: common_enums::Currency,
+        metadata: Option<serde_json::Value>,
+    ) -> PaymentsAuthorizeData {
+        PaymentsAuthorizeData {
+            payment_method_data,
+            amount: minor_amount,
+            order_tax_amount: None,
+            email: None,
+            customer_name: None,
+            currency,
+            confirm: true,
+            statement_descriptor_suffix: None,
+            statement_descriptor: None,
+            // La homologación mandó ventas (`PaymentCardSaleTransaction`), o sea captura
+            // automática.
+            capture_method: Some(common_enums::CaptureMethod::Automatic),
+            router_return_url: None,
+            webhook_url: None,
+            complete_authorize_url: None,
+            setup_future_usage: None,
+            mandate_id: None,
+            off_session: None,
+            customer_acceptance: None,
+            setup_mandate_details: None,
+            browser_info: None,
+            order_details: None,
+            order_category: None,
+            session_token: None,
+            enrolled_for_3ds: false,
+            related_transaction_id: None,
+            payment_experience: None,
+            payment_method_type: None,
+            surcharge_details: None,
+            customer_id: None,
+            request_incremental_authorization: false,
+            metadata,
+            authentication_data: None,
+            request_extended_authorization: None,
+            split_payments: None,
+            minor_amount: MinorUnit::new(minor_amount),
+            merchant_order_reference_id: None,
+            integrity_object: None,
+            shipping_cost: None,
+            additional_payment_method_data: None,
+            merchant_account_id: None,
+            merchant_config_currency: None,
+            connector_testing_data: None,
+            order_id: None,
+            locale: None,
+            payment_channel: None,
+            enable_partial_authorization: None,
+            enable_overcapture: None,
+        }
+    }
+
+    /// Serializa el request de Authorize por el mismo camino que `get_request_body`.
+    fn authorize_payload(router_data: &PaymentsAuthorizeRouterData) -> serde_json::Value {
+        let amount = StringMajorUnitForConnector
+            .convert(router_data.request.minor_amount, router_data.request.currency)
+            .unwrap();
+        let wrapped = FiservemeaRouterData::from((amount, router_data));
+        let request = FiservemeaPaymentsRequest::try_from(&wrapped).unwrap();
+        serde_json::to_value(&request).unwrap()
+    }
+
+    /// Venta con tarjeta tal como la armaría el conector, con los datos del checklist.
+    fn cert_card_sale_payload(
+        store_id: &str,
+        reference_id: &str,
+        card_number: &str,
+        minor_amount: i64,
+        currency: common_enums::Currency,
+        metadata: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        let router_data: PaymentsAuthorizeRouterData = cert_router_data(
+            store_id,
+            reference_id,
+            cert_authorize_data(
+                cert_card_data(card_number),
+                minor_amount,
+                currency,
+                metadata,
+            ),
+        );
+        authorize_payload(&router_data)
+    }
+
+    /// evidencia.jsonl línea 0 — "AR SALE 1 pago", HTTP 200 APPROVED.
+    #[test]
+    fn cert_case_sale_one_payment_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053416-01-sale",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" },
+            "order": { "orderId": "PX-1786053416-01-sale" },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "5165850000000008",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1786053416-01-sale",
+            CERT_CARD,
+            100_000,
+            common_enums::Currency::ARS,
+            None,
+        );
+        assert_eq!(got, expected);
+    }
+
+    /// evidencia.jsonl línea 1 — "AR SALE 1 pago USD", HTTP 200 APPROVED.
+    #[test]
+    fn cert_case_sale_usd_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053417-02-saleusd",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "USD" },
+            "order": { "orderId": "PX-1786053417-02-saleusd" },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "5165850000000008",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1786053417-02-saleusd",
+            CERT_CARD,
+            100_000,
+            common_enums::Currency::USD,
+            None,
+        );
+        assert_eq!(got, expected);
+    }
+
+    /// evidencia.jsonl línea 3 — "AR SALE cuotas (6)", HTTP 200 APPROVED.
+    /// `numberOfInstallments` viaja como NÚMERO, no como string.
+    #[test]
+    fn cert_case_sale_installments_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053420-04-cuotas",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" },
+            "order": {
+                "orderId": "PX-1786053420-04-cuotas",
+                "installmentOptions": { "numberOfInstallments": 6 }
+            },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "5165850000000008",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1786053420-04-cuotas",
+            CERT_CARD,
+            100_000,
+            common_enums::Currency::ARS,
+            Some(serde_json::json!({ "installments": 6 })),
+        );
+        assert_eq!(got, expected);
+        assert!(got["order"]["installmentOptions"]["numberOfInstallments"].is_number());
+    }
+
+    /// evidencia.jsonl línea 4 — "AR DYNAMIC MERCHANT NAME", HTTP 200 APPROVED.
+    /// `softDescriptor` va DENTRO de `order`, y el campo es `dynamicMerchantName`.
+    #[test]
+    fn cert_case_dynamic_merchant_name_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053422-05-dmn",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" },
+            "order": {
+                "orderId": "PX-1786053422-05-dmn",
+                "softDescriptor": { "dynamicMerchantName": "PXSOL*Reservas" }
+            },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "5165850000000008",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1786053422-05-dmn",
+            CERT_CARD,
+            100_000,
+            common_enums::Currency::ARS,
+            Some(serde_json::json!({ "dynamic_merchant_name": "PXSOL*Reservas" })),
+        );
+        assert_eq!(got, expected);
+        // El gateway rechaza un `softDescriptor` a nivel raíz con INVALID_INPUT.
+        assert!(got.get("softDescriptor").is_none());
+    }
+
+    /// evidencia.jsonl línea 17 — "AR SALE TOKEN MTRG 1 pago", HTTP 200 APPROVED.
+    /// El flujo MTRG integrado (OnTheGo) manda el PAN real con CVV: es Fiserv quien resuelve
+    /// el Network Token. No lleva criptograma ni nada distinto de una venta normal.
+    #[test]
+    fn cert_case_token_mtrg_one_payment_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053444-12-mtrg",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" },
+            "order": { "orderId": "PX-1786053444-12-mtrg" },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "4622943127032366",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1786053444-12-mtrg",
+            CERT_CARD_MTRG,
+            100_000,
+            common_enums::Currency::ARS,
+            None,
+        );
+        assert_eq!(got, expected);
+    }
+
+    /// evidencia.jsonl línea 15 — "AR SALE cuotas TOKEN GW", HTTP 200 APPROVED.
+    #[test]
+    fn cert_case_token_gw_installments_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentTokenSaleTransaction",
+            "merchantTransactionId": "PX-1786053439-10-tokgw",
+            "storeId": "5926072902",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" },
+            "order": {
+                "orderId": "PX-1786053439-10-tokgw",
+                "installmentOptions": { "numberOfInstallments": 6 }
+            },
+            "paymentMethod": {
+                "paymentToken": {
+                    "value": "CF49734F-986F-4FD1-8040-9A16657E9B3E",
+                    "tokenOriginStoreId": "5926072902"
+                }
+            }
+        });
+        let mut router_data: PaymentsAuthorizeRouterData = cert_router_data(
+            CERT_STORE_TOKEN_GW,
+            "PX-1786053439-10-tokgw",
+            cert_authorize_data(
+                cert_card_data(CERT_CARD),
+                100_000,
+                common_enums::Currency::ARS,
+                Some(serde_json::json!({ "installments": 6 })),
+            ),
+        );
+        // Hyperswitch corre primero el flujo PaymentMethodToken y devuelve el token acá.
+        router_data.payment_method_token = Some(PaymentMethodToken::Token(Secret::new(
+            "CF49734F-986F-4FD1-8040-9A16657E9B3E".to_string(),
+        )));
+        assert_eq!(authorize_payload(&router_data), expected);
+    }
+
+    /// evidencia.jsonl línea 14 — "AR CREATE TOKEN GW" (`POST /payment-tokens`), HTTP 200.
+    /// `paymentCard` va a nivel raíz, NO bajo `paymentMethod`.
+    #[test]
+    fn cert_case_create_token_gw_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardPaymentTokenizationRequest",
+            "storeId": "5926072902",
+            "paymentCard": {
+                "number": "5165850000000008",
+                "expiryDate": { "month": "12", "year": "29" },
+                "securityCode": "123"
+            },
+            "createToken": { "reusable": true, "declineDuplicates": false }
+        });
+        let router_data: TokenizationRouterData = cert_router_data(
+            CERT_STORE_TOKEN_GW,
+            "PX-1786053439-10-tokgw",
+            PaymentMethodTokenizationData {
+                payment_method_data: cert_card_data(CERT_CARD),
+                browser_info: None,
+                currency: common_enums::Currency::ARS,
+                amount: Some(100_000),
+                split_payments: None,
+                customer_acceptance: None,
+                setup_future_usage: None,
+                setup_mandate_details: None,
+                mandate_id: None,
+            },
+        );
+        let request = FiservemeaCreateTokenRequest::try_from(&router_data).unwrap();
+        assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+    }
+
+    /// evidencia.jsonl línea 2 — "AR SALE ZEROAUTH", HTTP 200 APPROVED.
+    /// El importe viaja como `"0"` (string, sin decimales), tal cual lo aceptó el gateway.
+    #[test]
+    fn cert_case_zeroauth_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "PaymentCardSaleTransaction",
+            "merchantTransactionId": "PX-1786053418-03-zeroauth",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "0", "currency": "ARS" },
+            "order": { "orderId": "PX-1786053418-03-zeroauth" },
+            "paymentMethod": {
+                "paymentCard": {
+                    "number": "5165850000000008",
+                    "expiryDate": { "month": "12", "year": "29" },
+                    "securityCode": "123"
+                }
+            }
+        });
+        let router_data: RouterData<SetupMandate, SetupMandateRequestData, PaymentsResponseData> =
+            cert_router_data(
+                CERT_STORE_AR,
+                "PX-1786053418-03-zeroauth",
+                SetupMandateRequestData {
+                    currency: common_enums::Currency::ARS,
+                    payment_method_data: cert_card_data(CERT_CARD),
+                    amount: Some(0),
+                    confirm: true,
+                    statement_descriptor_suffix: None,
+                    customer_acceptance: None,
+                    mandate_id: None,
+                    setup_future_usage: None,
+                    off_session: None,
+                    setup_mandate_details: None,
+                    router_return_url: None,
+                    webhook_url: None,
+                    browser_info: None,
+                    email: None,
+                    customer_name: None,
+                    return_url: None,
+                    payment_method_type: None,
+                    request_incremental_authorization: false,
+                    metadata: None,
+                    complete_authorize_url: None,
+                    capture_method: None,
+                    enrolled_for_3ds: false,
+                    related_transaction_id: None,
+                    minor_amount: Some(MinorUnit::new(0)),
+                    shipping_cost: None,
+                    connector_testing_data: None,
+                    customer_id: None,
+                    enable_partial_authorization: None,
+                    payment_channel: None,
+                },
+            );
+        let request = FiservemeaPaymentsRequest::try_from(&router_data).unwrap();
+        assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+    }
+
+    /// evidencia.jsonl línea 9 — "AR VOID (anulación)", HTTP 200 APPROVED.
+    /// El cuerpo lleva SÓLO `requestType` y `storeId`: ni importe ni orden.
+    #[test]
+    fn cert_case_void_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "VoidTransaction",
+            "storeId": "5926072901"
+        });
+        let router_data: PaymentsCancelRouterData = cert_router_data(
+            CERT_STORE_AR,
+            "PX-1786053424-07-void",
+            PaymentsCancelData {
+                connector_transaction_id: "84667286296".to_string(),
+                currency: Some(common_enums::Currency::ARS),
+                amount: Some(100_000),
+                minor_amount: Some(MinorUnit::new(100_000)),
+                // La venta original salió como `PaymentCardSaleTransaction`.
+                capture_method: Some(common_enums::CaptureMethod::Automatic),
+                ..Default::default()
+            },
+        );
+        let request = FiservemeaVoidRequest::try_from(&router_data).unwrap();
+        assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+    }
+
+    fn cert_refund_payload(reference_id: &str, minor_refund_amount: i64) -> serde_json::Value {
+        let router_data: RefundsRouterData<Execute> = cert_router_data(
+            CERT_STORE_AR,
+            reference_id,
+            RefundsData {
+                refund_id: "ref_1".to_string(),
+                connector_transaction_id: "84667286298".to_string(),
+                connector_refund_id: None,
+                currency: common_enums::Currency::ARS,
+                payment_amount: 100_000,
+                reason: None,
+                webhook_url: None,
+                refund_amount: minor_refund_amount,
+                connector_metadata: None,
+                refund_connector_metadata: None,
+                browser_info: None,
+                split_refunds: None,
+                minor_payment_amount: MinorUnit::new(100_000),
+                minor_refund_amount: MinorUnit::new(minor_refund_amount),
+                integrity_object: None,
+                refund_status: common_enums::RefundStatus::Pending,
+                merchant_account_id: None,
+                merchant_config_currency: None,
+                capture_method: Some(common_enums::CaptureMethod::Automatic),
+                additional_payment_method_data: None,
+            },
+        );
+        let amount = StringMajorUnitForConnector
+            .convert(
+                router_data.request.minor_refund_amount,
+                router_data.request.currency,
+            )
+            .unwrap();
+        let wrapped = FiservemeaRouterData::from((amount, &router_data));
+        let request = FiservemeaRefundRequest::try_from(&wrapped).unwrap();
+        serde_json::to_value(&request).unwrap()
+    }
+
+    /// evidencia.jsonl línea 11 — "AR RETURN total", HTTP 200 APPROVED.
+    #[test]
+    fn cert_case_return_total_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "ReturnTransaction",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "1000.00", "currency": "ARS" }
+        });
+        assert_eq!(
+            cert_refund_payload("PX-1786053425-08-rettot", 100_000),
+            expected
+        );
+    }
+
+    /// evidencia.jsonl línea 13 — "AR RETURN parcial", HTTP 200 APPROVED.
+    #[test]
+    fn cert_case_return_partial_matches_the_accepted_payload() {
+        let expected = serde_json::json!({
+            "requestType": "ReturnTransaction",
+            "storeId": "5926072901",
+            "transactionAmount": { "total": "500.00", "currency": "ARS" }
+        });
+        assert_eq!(
+            cert_refund_payload("PX-1786053426-09-retpar", 50_000),
+            expected
+        );
+    }
+
+    /// La captura NO está entre los 31 casos de la homologación: el checklist es todo ventas.
+    /// Este test sólo fija la forma del cuerpo que el conector emite (`PostAuthTransaction` +
+    /// `storeId` + `transactionAmount`), que es la que documenta la guía. NO está verificada
+    /// contra el gateway.
+    #[test]
+    fn capture_payload_shape_is_post_auth_with_amount_not_verified_against_cert() {
+        let router_data: PaymentsCaptureRouterData = cert_router_data(
+            CERT_STORE_AR,
+            "PX-capture",
+            PaymentsCaptureData {
+                amount_to_capture: 100_000,
+                currency: common_enums::Currency::ARS,
+                connector_transaction_id: "84667286296".to_string(),
+                payment_amount: 100_000,
+                minor_payment_amount: MinorUnit::new(100_000),
+                minor_amount_to_capture: MinorUnit::new(100_000),
+                capture_method: Some(common_enums::CaptureMethod::Manual),
+                ..Default::default()
+            },
+        );
+        let amount = StringMajorUnitForConnector
+            .convert(
+                router_data.request.minor_amount_to_capture,
+                router_data.request.currency,
+            )
+            .unwrap();
+        let wrapped = FiservemeaRouterData::from((amount, &router_data));
+        let request = FiservemeaCaptureRequest::try_from(&wrapped).unwrap();
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            serde_json::json!({
+                "requestType": "PostAuthTransaction",
+                "storeId": "5926072901",
+                "transactionAmount": { "total": "1000.00", "currency": "ARS" }
+            })
+        );
+    }
+
+    /// `merchantTransactionId` sale de `merchant_order_reference_id` cuando el comercio lo
+    /// manda, y de la referencia del conector cuando no. `order.orderId` es SIEMPRE la
+    /// referencia del conector: es con la que después se consulta `GET /orders/{orderId}`.
+    /// En la homologación los dos coincidían, así que este test es el que separa los caminos.
+    #[test]
+    fn merchant_transaction_id_and_order_id_come_from_different_sources() {
+        let mut request_data = cert_authorize_data(
+            cert_card_data(CERT_CARD),
+            100_000,
+            common_enums::Currency::ARS,
+            None,
+        );
+        request_data.merchant_order_reference_id = Some("factura-del-comercio-123".to_string());
+        let router_data: PaymentsAuthorizeRouterData =
+            cert_router_data(CERT_STORE_AR, "PX-ref-del-conector", request_data);
+        let got = authorize_payload(&router_data);
+        assert_eq!(got["merchantTransactionId"], "factura-del-comercio-123");
+        assert_eq!(got["order"]["orderId"], "PX-ref-del-conector");
+    }
+
+    /// Referencia de 66 caracteres: es lo que produce un `payment_id` del comercio del largo
+    /// máximo (64) más el sufijo `_1` del intento.
+    const REFERENCIA_LARGA: &str =
+        "PXSOL-RESERVA-2026-08-12-HOTEL-1234-HABITACION-501-CONFIRMADA-XY_1";
+
+    /// El gateway rechaza con 400 INVALID_INPUT un `merchantTransactionId` de 41 caracteres
+    /// (verificado en cert: 40 pasa, 41 falla). Los dos caminos que emiten el campo tienen que
+    /// recortarlo, incluido el Zero Auth — que antes lo mandaba entero y tiraba abajo la
+    /// verificación de tarjeta de cualquier comercio con un `payment_id` largo.
+    #[test]
+    fn merchant_transaction_id_is_capped_at_40_in_both_flows() {
+        assert_eq!(REFERENCIA_LARGA.chars().count(), 66);
+
+        let authorize: PaymentsAuthorizeRouterData = cert_router_data(
+            CERT_STORE_AR,
+            REFERENCIA_LARGA,
+            cert_authorize_data(
+                cert_card_data(CERT_CARD),
+                100_000,
+                common_enums::Currency::ARS,
+                None,
+            ),
+        );
+        let got = authorize_payload(&authorize);
+        assert_eq!(
+            got["merchantTransactionId"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count(),
+            FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN
+        );
+
+        let zero_auth: RouterData<SetupMandate, SetupMandateRequestData, PaymentsResponseData> =
+            cert_router_data(
+                CERT_STORE_AR,
+                REFERENCIA_LARGA,
+                SetupMandateRequestData {
+                    currency: common_enums::Currency::ARS,
+                    payment_method_data: cert_card_data(CERT_CARD),
+                    amount: Some(0),
+                    confirm: true,
+                    statement_descriptor_suffix: None,
+                    customer_acceptance: None,
+                    mandate_id: None,
+                    setup_future_usage: None,
+                    off_session: None,
+                    setup_mandate_details: None,
+                    router_return_url: None,
+                    webhook_url: None,
+                    browser_info: None,
+                    email: None,
+                    customer_name: None,
+                    return_url: None,
+                    payment_method_type: None,
+                    request_incremental_authorization: false,
+                    metadata: None,
+                    complete_authorize_url: None,
+                    capture_method: None,
+                    enrolled_for_3ds: false,
+                    related_transaction_id: None,
+                    minor_amount: Some(MinorUnit::new(0)),
+                    shipping_cost: None,
+                    connector_testing_data: None,
+                    customer_id: None,
+                    enable_partial_authorization: None,
+                    payment_channel: None,
+                },
+            );
+        let request = FiservemeaPaymentsRequest::try_from(&zero_auth).unwrap();
+        let got = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            got["merchantTransactionId"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count(),
+            FISERVEMEA_MERCHANT_TRANSACTION_ID_MAX_LEN
+        );
+        // El `orderId` NO se recorta: es la clave con la que después se consulta
+        // `GET /orders/{orderId}`, así que tiene que quedar igual a la referencia.
+        assert_eq!(got["order"]["orderId"], REFERENCIA_LARGA);
+    }
+
+    /// 1 cuota no emite `installmentOptions`: el harness tampoco lo mandó en los casos de
+    /// 1 pago que el gateway aprobó (evidencia.jsonl líneas 0, 82, 91).
+    #[test]
+    fn a_single_installment_does_not_emit_installment_options() {
+        let got = cert_card_sale_payload(
+            CERT_STORE_AR,
+            "PX-1-cuota",
+            CERT_CARD,
+            100_000,
+            common_enums::Currency::ARS,
+            Some(serde_json::json!({ "installments": 1 })),
+        );
+        assert!(got["order"].get("installmentOptions").is_none());
+    }
+    #[test]
+    fn psync_of_a_voided_sale_is_not_reported_as_charged() {
+        // Respuesta REAL de certificación: se consultó una venta que había sido anulada. El
+        // gateway devuelve el tipo y el estado de la VENTA (SALE / APPROVED) pero con
+        // `transactionState: VOIDED`. Mirando sólo el tipo, el pago se reportaba como cobrado:
+        // plata que el comercio cree haber cobrado y no cobró.
+        let raw = serde_json::json!({
+            "type": "transactionResponse",
+            "ipgTransactionId": "84668213533",
+            "transactionType": "SALE",
+            "transactionStatus": "APPROVED",
+            "transactionResult": "APPROVED",
+            "transactionState": "VOIDED"
+        });
+        let response: FiservemeaPaymentsResponse = serde_json::from_value(raw).unwrap();
+        assert_eq!(
+            map_status(
+                response.transaction_status,
+                response.transaction_result,
+                response.transaction_type,
+                response.transaction_state.as_deref(),
+            ),
+            common_enums::AttemptStatus::Voided
+        );
+    }
+
+    #[test]
+    fn transaction_state_only_overrides_when_it_is_terminal_and_known() {
+        // CAPTURED y WAITING no agregan nada sobre el tipo, y un valor que no conocemos no debe
+        // pisar la clasificación que sí conocemos.
+        assert_eq!(
+            map_transaction_state(Some("VOIDED")),
+            Some(common_enums::AttemptStatus::Voided)
+        );
+        assert_eq!(
+            map_transaction_state(Some("DECLINED")),
+            Some(common_enums::AttemptStatus::Failure)
+        );
+        assert_eq!(map_transaction_state(Some("CAPTURED")), None);
+        assert_eq!(map_transaction_state(Some("WAITING")), None);
+        assert_eq!(map_transaction_state(Some("ESTADO_NUEVO")), None);
+        assert_eq!(map_transaction_state(None), None);
+        // Y una venta capturada sigue siendo un cobro.
+        assert_eq!(
+            map_approved_status(Some(&FiservemeaTransactionType::Sale), Some("CAPTURED")),
+            common_enums::AttemptStatus::Charged
+        );
+    }
+
 }


### PR DESCRIPTION
## Qué es esto

Deja al conector `fiservemea` en condiciones de ejecutar los 31 casos del checklist de
homologación de Fiserv desde Hyperswitch, en vez de desde un script suelto.

El trabajo salió de auditar el conector contra la documentación original de Fiserv (guía de
integración Argentina 2026, manual de Network Token MTRG, manual de Zero Auth y las tablas de
códigos de rechazo) y de comprobar cada afirmación contra el gateway de certificación.

## Los defectos que se arreglan

Tres de ellos costaban plata:

- **Un pago sin `capture_method` explícito se enviaba como pre-autorización.** `is_auto_capture`
  mapeaba `None` a manual, al revés del helper canónico de Hyperswitch. La retención quedaba sin
  capturar.
- **El PSync de una venta anulada la reportaba como cobrada.** `map_status` parseaba
  `transactionState` y no lo leía nunca. Comprobado en certificación: consultar una venta ya
  anulada devuelve `transactionType: SALE` + `transactionStatus: APPROVED` +
  `transactionState: VOIDED`.
- **Los rechazos del emisor llegaban sin código ni motivo.** IPG los devuelve con HTTP 2xx y el
  `TryFrom` respondía siempre `Ok(...)`: el intento quedaba en `Failure` y el comercio sin saber
  por qué.

Y tres que impedían diagnosticar u operar:

- `FiservemeaErrorResponse` no declaraba `camelCase`, así que perdía el `apiTraceId` —el
  identificador con el que el soporte de Fiserv busca en sus logs—, el `ipgTransactionId` (que
  traen 90 de 107 respuestas de error) y el `secure3dResponse`, que es el dato que la homologación
  pide informar y que llega justamente por el camino de error en 11 de las 22 filas 3DS.
- `merchantTransactionId` se enviaba sin truncar a 40 caracteres. Comprobado: 41 devuelve
  `400 INVALID_INPUT`.
- Un valor de enum no contemplado hacía fallar el parseo de un cobro aprobado.

## Lo que se agrega

- **3DS de punta a punta.** El `methodForm` que manda Fiserv es un iframe oculto con un form que
  apunta a ese mismo iframe: entregado crudo, el desafío se renderiza invisible y el tarjetahabiente
  nunca vuelve al comercio. Ahora va dentro de una página que lo aloja, espera el mínimo de 10
  segundos que exige la guía y navega la ventana principal. `termURL` y `methodNotificationURL`
  pasan a ser distinguibles: la notificación que el ACS publica dentro del iframe se degrada a una
  consulta, y la continuación la manda el retorno del navegador, que es el único visible. Se agrega
  una guarda para el `30056` con el que el gateway rechaza una continuación duplicada, que sin ella
  pisaba un pago ya aprobado.
- **Data Only** con la clase base `Secure3DAuthenticationRequest` —la subclase rechaza
  `messageCategory`— y gateado a Mastercard, porque con otra marca el gateway responde `50738`.
  `challengeIndicator` y `challengeWindowSize` pasan a ser configurables por metadata.
- **PSync por `orderId`**, que es el caso "INQUIRY ORDER" del checklist y además permite recuperar
  el estado de un rechazo que no devolvió `ipgTransactionId`.
- **Card on File y Network Token**: emparejamiento Network Token ↔ PAN (requisito explícito del
  manual MTRG para poder conciliar), `storedCredentials` con el mapeo por marca de la guía —que no
  es simétrico entre Visa y Mastercard—, `schemeTransactionId` devuelto como `network_txn_id`, y
  `mandate_reference` para que el token se pueda reutilizar.

## Cómo se verificó

- **172 tests** en el conector, en verde. Clippy `--all-targets` sin warnings propios.
- 20 de esos tests comparan por igualdad de JSON el payload que genera el conector contra el que el
  gateway aceptó con HTTP 200, caso por caso del checklist.
- Las **579 respuestas reales** de las corridas de homologación pasan por los `TryFrom` del
  conector sin que ninguna falle a deserializar.
- **41 llamadas en vivo** al gateway de certificación con los payloads que genera el conector: 35
  con HTTP 200 y ningún rechazo por forma.
- **Pagos de punta a punta por el router** (levantado con Postgres y Redis): sale en ARS, cuotas,
  dynamic merchant name, pre-auth, captura, void, refunds y PSync, aprobados por el gateway.

## Lo que no está verificado

- **Los 21 casos 3DS no pasaron por el router.** Está comprobado que los payloads del conector son
  correctos y que el gateway los acepta —un representante de cada forma de flujo cerró APPROVED con
  el código esperado—, pero el ida y vuelta del navegador no se validó y requiere un browser.
- **`methodNotificationStatus` termina siendo siempre `EXPECTED_BUT_NOT_RECEIVED`** en el flujo
  real, como consecuencia de separar las dos URLs: el ACS publica el `threeDSMethodData` en la URL
  de notificación y el retorno del navegador, que es el que continúa, ya no lo trae. El gateway lo
  acepta y la guía contempla el caso, pero conviene saberlo.
- **Card on File y el passthrough con criptograma no se ejercieron contra el gateway.** El
  certificación no devolvió `schemeTransactionId` en ninguna de las 579 respuestas, así que la
  recurrencia de Visa no se pudo armar. Por eso el conector **no** se agrega a
  `network_tokenization_supported_connectors`.
- Uruguay (tienda, moneda y `taxRefundRequestData`) no se probó.

## Casos del checklist que dependen de Fiserv, no del código

- **DataOnly**: el gateway responde `50655` / `responseCode3dSecure 8` con el payload exacto del
  ejemplo de la guía, en las dos tiendas y con las dos Mastercard. Se descartó que sea el payload:
  la misma tarjeta sin `messageCategory` negocia 3DS 2.2 sin problema, y por la vía de proveedor
  externo la misma tienda aprueba con código `A`. Falta habilitación de la modalidad.
- **Sale en cuotas con TOKEN MTRG**: el flujo OnTheGo funciona y el Network Token se provisiona
  (PAN 462294/2366 → token 432312/7867), pero con `installmentOptions` el gateway responde
  `11101 installment only supported for local cards`. No es por el Network Token: en la misma
  tienda, la Visa 4704550000000005 también se procesa sustituida por Network Token y sí acepta 6
  cuotas. El PAN de prueba no resuelve como tarjeta local argentina.
- **3DSMethod Rejected**: la tarjeta que indica el checklist devuelve código 6 y no ejecuta el paso
  3DSMethod; la que la guía asigna a ese escenario devuelve 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumen

El PR amplía y corrige el conector `fiservemea` para cubrir los 31 casos del checklist de homologación de Fiserv.

### Cambios principales

- Se corrigió la captura automática y el estado de pagos anulados.
- Se propagaron códigos, motivos de rechazo, identificadores de transacción y metadatos de network decline.
- Se mejoró la deserialización de respuestas exitosas y de error.
- Se agregó tolerancia ante valores de enum desconocidos.
- Se implementó el truncado de `merchantTransactionId`.
- Se agregó soporte 3DS para:
  - Notificaciones de método mediante `GET`.
  - Continuación mediante `PATCH`.
  - Redirecciones.
  - Protección de continuación duplicada mediante idempotencia.
- Se mejoró PSync con fallback desde `transactionId` hacia `orderId`.
- Se soportaron respuestas de PSync basadas en transacción y en orden.
- Se agregó soporte para Card on File, network token, `storedCredentials`, `schemeTransactionId` y `mandate_reference`.
- Se marcó el soporte de mandatos en el conector.
- Se evitó enviar un cuerpo por defecto sin firma en refund sync.
- Se agregaron módulos de payloads y respuestas de certificación con cobertura para pagos, tokenización, 3DS, capturas, anulaciones, reembolsos, PSync y errores.
- Se actualizaron las configuraciones de desarrollo, pruebas, sandbox y producción para habilitar tokenización con tarjetas y flujo `mandates`.
- `fiservemea` se agregó a las listas de conectores compatibles con pagos con y sin mandato.
- No se agregó `fiservemea` a la network tokenization propia de Hyperswitch porque ese flujo no fue probado contra Fiserv.

### Impacto arquitectónico

El conector ahora usa flujos específicos de Fiserv para continuación 3DS, consulta por `orderId` y operaciones de mandatos. La capa de conversión de respuestas conserva más información del gateway y aplica fallbacks para distintos formatos de respuesta. Las pruebas de certificación usan fixtures reales y permiten validar serialización, deserialización y construcción de solicitudes sin depender siempre de credenciales activas.

### Seguridad y robustez

- La continuación 3DS evita operaciones duplicadas.
- Las URLs de PSync aplican codificación segura para valores de `orderId`.
- Las respuestas de error conservan metadatos necesarios para aplicar decisiones correctas de rechazo.
- Los valores de enum desconocidos no provocan fallos de deserialización.
- La configuración mantiene deshabilitados los tokens de larga duración.
- La network tokenization no se habilita sin validación específica del gateway.

### Rendimiento

PSync evita consultas innecesarias al usar primero el identificador de transacción y consultar por `orderId` solo como fallback. La protección contra continuaciones duplicadas también evita llamadas repetidas al gateway. No se introducen procesos persistentes ni cambios que aumenten el coste de las operaciones normales.

### Validación

- Se ejecutaron 172 tests del conector.
- Se deserializaron correctamente 579 respuestas reales.
- Se realizaron 41 llamadas al gateway de certificación.
- 35 llamadas recibieron HTTP 200.
- Se verificaron mediante el router pagos, capturas, anulaciones, reembolsos y PSync.

Los 21 casos 3DS no se validaron mediante el router. Card on File y passthrough con criptograma no se ejercitaron contra el gateway. Uruguay tampoco fue probado. Algunos casos dependen de habilitaciones o restricciones de Fiserv.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->