### PR TITLE
feat(mercadopago): Checkout Pro hosted-checkout wallet flow

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2889,7 +2889,9 @@ impl GetPaymentMethodType for WalletData {
             Self::MbWayRedirect(_) => api_enums::PaymentMethodType::MbWay,
             Self::MobilePayRedirect(_) => api_enums::PaymentMethodType::MobilePay,
             Self::PaypalRedirect(_) | Self::PaypalSdk(_) => api_enums::PaymentMethodType::Paypal,
-            Self::MercadoPagoSdk(_) => api_enums::PaymentMethodType::MercadoPago,
+            Self::MercadoPagoSdk(_) | Self::MercadoPagoCheckoutPro {} => {
+                api_enums::PaymentMethodType::MercadoPago
+            }
             Self::Paze(_) => api_enums::PaymentMethodType::Paze,
             Self::SamsungPay(_) => api_enums::PaymentMethodType::SamsungPay,
             Self::TwintRedirect {} => api_enums::PaymentMethodType::Twint,
@@ -3899,6 +3901,9 @@ pub enum WalletData {
     /// The wallet data for Mercado Pago SDK (tokenized card)
     #[schema(title = "MercadoPagoSdk")]
     MercadoPagoSdk(MercadoPagoSdkData),
+    /// The wallet data for Mercado Pago Checkout Pro (hosted checkout redirect)
+    #[schema(title = "MercadoPagoCheckoutPro")]
+    MercadoPagoCheckoutPro {},
     /// The wallet data for Paysera
     #[schema(title = "Paysera")]
     Paysera(PayseraData),
@@ -3979,6 +3984,7 @@ impl GetAddressFromPaymentMethodData for WalletData {
             | Self::GooglePayThirdPartySdk(_)
             | Self::PaypalSdk(_)
             | Self::MercadoPagoSdk(_)
+            | Self::MercadoPagoCheckoutPro {}
             | Self::Paze(_)
             | Self::SamsungPay(_)
             | Self::TwintRedirect {}

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -6850,5 +6850,7 @@ api_key = "API Key"
 api_key = "API Key"
 
 [mercadopago]
+[[mercadopago.wallet]]
+  payment_method_type = "mercado_pago"
 [mercadopago.connector_auth.HeaderKey]
 api_key="Access Token"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -5519,5 +5519,7 @@ api_key = "API Key"
 api_key = "API Key"
 
 [mercadopago]
+[[mercadopago.wallet]]
+  payment_method_type = "mercado_pago"
 [mercadopago.connector_auth.HeaderKey]
 api_key="Access Token"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -6833,5 +6833,7 @@ api_key = "API Key"
 api_key = "API Key"
 
 [mercadopago]
+[[mercadopago.wallet]]
+  payment_method_type = "mercado_pago"
 [mercadopago.connector_auth.HeaderKey]
 api_key="Access Token"

--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -200,9 +200,10 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
             | WalletData::GooglePayRedirect(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                "Payment method".to_string(),
-            ))?,
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => Err(
+                errors::ConnectorError::NotImplemented("Payment method".to_string()),
+            )?,
         };
         Ok(payment_data)
     }

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -2375,7 +2375,8 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for AdyenPaymentMethod
             | WalletData::CashappQr(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("Adyen"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/connectors/airwallex/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/airwallex/transformers.rs
@@ -831,7 +831,8 @@ fn get_wallet_details(
         | WalletData::SwishQr(_)
         | WalletData::Mifinity(_)
         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+        | WalletData::MercadoPagoSdk(_)
+        | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("airwallex"),
         ))?,
     };

--- a/crates/hyperswitch_connectors/src/connectors/amazonpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/amazonpay.rs
@@ -393,7 +393,8 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
                 | WalletDataPaymentMethod::Paysera(_)
                 | WalletDataPaymentMethod::Skrill(_)
                 | WalletDataPaymentMethod::Mifinity(_)
-                | WalletDataPaymentMethod::MercadoPagoSdk(_) => {
+                | WalletDataPaymentMethod::MercadoPagoSdk(_)
+                | WalletDataPaymentMethod::MercadoPagoCheckoutPro {} => {
                     Err(errors::ConnectorError::NotImplemented(
                         utils::get_unimplemented_payment_method_error_message("amazonpay"),
                     )

--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -543,9 +543,12 @@ impl TryFrom<&SetupMandateRouterData> for CreateCustomerPaymentProfileRequest {
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("authorizedotnet"),
-                )),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("authorizedotnet"),
+                    ))
+                }
             },
             PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::PayLater(_)
@@ -2255,7 +2258,8 @@ fn get_wallet_data(
         | WalletData::SwishQr(_)
         | WalletData::Mifinity(_)
         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+        | WalletData::MercadoPagoSdk(_)
+        | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("authorizedotnet"),
         ))?,
     }

--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -324,9 +324,12 @@ impl TryFrom<&SetupMandateRouterData> for BankOfAmericaPaymentsRequest {
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("BankOfAmerica"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("BankOfAmerica"),
+                    ))?
+                }
             },
             PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::PayLater(_)
@@ -1112,12 +1115,15 @@ impl TryFrom<&BankOfAmericaRouterData<&PaymentsAuthorizeRouterData>>
                         | WalletData::SwishQr(_)
                         | WalletData::Mifinity(_)
                         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                            utils::get_unimplemented_payment_method_error_message(
-                                "Bank of America",
-                            ),
-                        )
-                        .into()),
+                        | WalletData::MercadoPagoSdk(_)
+                        | WalletData::MercadoPagoCheckoutPro {} => {
+                            Err(errors::ConnectorError::NotImplemented(
+                                utils::get_unimplemented_payment_method_error_message(
+                                    "Bank of America",
+                                ),
+                            )
+                            .into())
+                        }
                     },
                     // If connector_mandate_id is present MandatePayment will be the PMD, the case will be handled in the first `if` clause.
                     // This is a fallback implementation in the event of catastrophe.

--- a/crates/hyperswitch_connectors/src/connectors/barclaycard/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/barclaycard/transformers.rs
@@ -1559,10 +1559,13 @@ impl TryFrom<&BarclaycardRouterData<&PaymentsAuthorizeRouterData>> for Barclayca
                 | WalletData::BluecodeRedirect {}
                 | WalletData::AmazonPay(_)
                 | WalletData::Mifinity(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Barclaycard"),
-                )
-                .into()),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Barclaycard"),
+                    )
+                    .into())
+                }
             },
             PaymentMethodData::MandatePayment
             | PaymentMethodData::CardRedirect(_)

--- a/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
@@ -402,9 +402,12 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
                 | WalletData::WeChatPayQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("bluesnap"),
-                )),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("bluesnap"),
+                    ))
+                }
             },
             PaymentMethodData::PayLater(_)
             | PaymentMethodData::BankRedirect(_)

--- a/crates/hyperswitch_connectors/src/connectors/boku/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/boku/transformers.rs
@@ -206,7 +206,8 @@ fn get_wallet_type(wallet_data: &WalletData) -> Result<String, errors::Connector
         | WalletData::SwishQr(_)
         | WalletData::Mifinity(_)
         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+        | WalletData::MercadoPagoSdk(_)
+        | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("boku"),
         )),
     }

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -139,10 +139,13 @@ impl TryFrom<&TokenizationRouterData> for TokenRequest {
                 | WalletData::WeChatPayQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("checkout"),
-                )
-                .into()),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("checkout"),
+                    )
+                    .into())
+                }
             },
             PaymentMethodData::Card(_)
             | PaymentMethodData::PayLater(_)

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -317,9 +317,12 @@ impl TryFrom<&SetupMandateRouterData> for CybersourceZeroMandateRequest {
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Cybersource"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Cybersource"),
+                    ))?
+                }
             },
             PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::PayLater(_)
@@ -2515,10 +2518,15 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                         | WalletData::AmazonPay(_)
                         | WalletData::Mifinity(_)
                         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                            utils::get_unimplemented_payment_method_error_message("Cybersource"),
-                        )
-                        .into()),
+                        | WalletData::MercadoPagoSdk(_)
+                        | WalletData::MercadoPagoCheckoutPro {} => {
+                            Err(errors::ConnectorError::NotImplemented(
+                                utils::get_unimplemented_payment_method_error_message(
+                                    "Cybersource",
+                                ),
+                            )
+                            .into())
+                        }
                     },
                     // If connector_mandate_id is present MandatePayment will be the PMD, the case will be handled in the first `if` clause.
                     // This is a fallback implementation in the event of catastrophe.

--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -589,10 +589,13 @@ impl TryFrom<&FiuuRouterData<&PaymentsAuthorizeRouterData>> for FiuuPaymentReque
                     | WalletData::SwishQr(_)
                     | WalletData::Mifinity(_)
                     | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                        utils::get_unimplemented_payment_method_error_message("fiuu"),
-                    )
-                    .into()),
+                    | WalletData::MercadoPagoSdk(_)
+                    | WalletData::MercadoPagoCheckoutPro {} => {
+                        Err(errors::ConnectorError::NotImplemented(
+                            utils::get_unimplemented_payment_method_error_message("fiuu"),
+                        )
+                        .into())
+                    }
                 },
                 PaymentMethodData::CardRedirect(_)
                 | PaymentMethodData::PayLater(_)

--- a/crates/hyperswitch_connectors/src/connectors/globepay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/globepay/transformers.rs
@@ -89,9 +89,12 @@ impl TryFrom<&GlobepayRouterData<&types::PaymentsAuthorizeRouterData>> for Globe
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    get_unimplemented_payment_method_error_message("globepay"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        get_unimplemented_payment_method_error_message("globepay"),
+                    ))?
+                }
             },
             PaymentMethodData::Card(_)
             | PaymentMethodData::CardRedirect(_)

--- a/crates/hyperswitch_connectors/src/connectors/mercadopago.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mercadopago.rs
@@ -8,7 +8,6 @@ use common_utils::{
     types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector},
 };
 use error_stack::ResultExt;
-use crate::utils::RefundsRequestData;
 use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
     router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
@@ -42,7 +41,7 @@ use hyperswitch_interfaces::{
 use masking::{Mask, PeekInterface};
 use transformers as mercadopago;
 
-use crate::{constants::headers, types::ResponseRouterData, utils};
+use crate::{constants::headers, types::ResponseRouterData, utils, utils::RefundsRequestData};
 
 const PXSOL_PLATFORM_ID: &str = "dev_ab8e21775bb211ed88d80242ac130004";
 
@@ -133,7 +132,10 @@ impl ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, Pay
         data: &hyperswitch_domain_models::types::TokenizationRouterData,
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
-    ) -> CustomResult<hyperswitch_domain_models::types::TokenizationRouterData, errors::ConnectorError>
+    ) -> CustomResult<
+        hyperswitch_domain_models::types::TokenizationRouterData,
+        errors::ConnectorError,
+    >
     where
         PaymentsResponseData: Clone,
     {
@@ -296,16 +298,25 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             masking::Secret::new(PXSOL_PLATFORM_ID.to_string()).into_masked(),
         ));
         // Add X-meli-session-id header if device_id is provided in metadata or frm_metadata (for anti-fraud)
-        let device_id = req.request.metadata.as_ref()
-            .and_then(|m| serde_json::from_value::<mercadopago::MercadopagoMetadata>(m.clone()).ok())
+        let device_id = req
+            .request
+            .metadata
+            .as_ref()
+            .and_then(|m| {
+                serde_json::from_value::<mercadopago::MercadopagoMetadata>(m.clone()).ok()
+            })
             .and_then(|mp| mp.device_id)
             .or_else(|| {
                 // Fallback to frm_metadata
-                req.frm_metadata.as_ref()
-                    .and_then(|m| serde_json::from_value::<mercadopago::MercadopagoMetadata>(m.peek().clone()).ok())
+                req.frm_metadata
+                    .as_ref()
+                    .and_then(|m| {
+                        serde_json::from_value::<mercadopago::MercadopagoMetadata>(m.peek().clone())
+                            .ok()
+                    })
                     .and_then(|mp| mp.device_id)
             });
-        
+
         if let Some(device_id) = device_id {
             headers.push((
                 "X-meli-session-id".to_string(),
@@ -321,10 +332,21 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
 
     fn get_url(
         &self,
-        _req: &PaymentsAuthorizeRouterData,
+        req: &PaymentsAuthorizeRouterData,
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        Ok(format!("{}/v1/payments", self.base_url(connectors)))
+        // Checkout Pro (hosted checkout) creates a preference; the card-token flow
+        // posts a payment directly.
+        if mercadopago::MercadopagoAuthorizeRequest::is_checkout_pro(
+            &req.request.payment_method_data,
+        ) {
+            Ok(format!(
+                "{}/checkout/preferences",
+                self.base_url(connectors)
+            ))
+        } else {
+            Ok(format!("{}/v1/payments", self.base_url(connectors)))
+        }
     }
 
     fn get_request_body(
@@ -340,7 +362,7 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
 
         let connector_router_data = mercadopago::MercadopagoRouterData::from((amount, req));
         let connector_req =
-            mercadopago::MercadopagoPaymentsRequest::try_from(&connector_router_data)?;
+            mercadopago::MercadopagoAuthorizeRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
 
@@ -372,9 +394,9 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsAuthorizeRouterData, errors::ConnectorError> {
-        let response: mercadopago::MercadopagoPaymentsResponse = res
+        let response: mercadopago::MercadopagoAuthorizeResponse = res
             .response
-            .parse_struct("MercadopagoPaymentsResponse")
+            .parse_struct("MercadopagoAuthorizeResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
@@ -416,17 +438,32 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Mer
         req: &PaymentsSyncRouterData,
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        let connector_payment_id = req
+        let base_url = self.base_url(connectors);
+
+        // Checkout Pro: the MP payment id does not exist until the buyer pays, so a
+        // wallet attempt without a transaction id syncs by searching OUR
+        // external_reference. The payment_id from the redirect query string is
+        // deliberately NOT used: it is buyer-controllable input (cross-payment
+        // substitution / bogus-id kills). The resource_id the sync returns is
+        // persisted on the attempt, promoting the real id.
+        match req
             .request
             .connector_transaction_id
             .get_connector_transaction_id()
-            .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
-
-        Ok(format!(
-            "{}/v1/payments/{}",
-            self.base_url(connectors),
-            connector_payment_id
-        ))
+        {
+            Ok(connector_payment_id) => {
+                Ok(format!("{base_url}/v1/payments/{connector_payment_id}"))
+            }
+            Err(_) if req.payment_method == enums::PaymentMethod::Wallet => Ok(format!(
+                "{}/v1/payments/search?external_reference={}&sort=date_created&criteria=desc",
+                base_url, req.connector_request_reference_id
+            )),
+            // Card-flow attempts always have the id from Authorize; without it there
+            // is nothing safe to sync against (keeps the pre-Checkout-Pro behavior).
+            Err(err) => {
+                Err(err).change_context(errors::ConnectorError::MissingConnectorTransactionID)
+            }
+        }
     }
 
     fn build_request(
@@ -450,9 +487,9 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Mer
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsSyncRouterData, errors::ConnectorError> {
-        let response: mercadopago::MercadopagoPaymentsResponse = res
+        let response: mercadopago::MercadopagoPSyncResponse = res
             .response
-            .parse_struct("MercadopagoPaymentsResponse")
+            .parse_struct("MercadopagoPSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
@@ -516,8 +553,10 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
             req.request.minor_amount_to_capture,
             req.request.currency,
         )?;
-        let connector_router_data = mercadopago::MercadopagoRouterData::from((amount_to_capture, req));
-        let connector_req = mercadopago::MercadopagoCaptureRequest::try_from(&connector_router_data)?;
+        let connector_router_data =
+            mercadopago::MercadopagoRouterData::from((amount_to_capture, req));
+        let connector_req =
+            mercadopago::MercadopagoCaptureRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
 
@@ -953,7 +992,9 @@ impl webhooks::IncomingWebhook for Mercadopago {
             .or_else(|| {
                 request
                     .body
-                    .parse_struct::<mercadopago::MercadopagoWebhookBodyEnum>("MercadopagoWebhookBodyEnum")
+                    .parse_struct::<mercadopago::MercadopagoWebhookBodyEnum>(
+                        "MercadopagoWebhookBodyEnum",
+                    )
                     .ok()
                     .map(|body| body.get_resource_id().to_lowercase())
             })
@@ -1063,10 +1104,11 @@ impl webhooks::IncomingWebhook for Mercadopago {
 // Connector Specifications
 // ============================================================================
 
+use std::sync::LazyLock;
+
 use hyperswitch_domain_models::router_response_types::{
     ConnectorInfo, PaymentMethodDetails, SupportedPaymentMethods, SupportedPaymentMethodsExt,
 };
-use std::sync::LazyLock;
 
 static MERCADOPAGO_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> =
     LazyLock::new(|| {
@@ -1101,6 +1143,21 @@ static MERCADOPAGO_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> 
             },
         );
 
+        // Checkout Pro (hosted checkout redirect). Auto-capture only: the payment is
+        // created and captured by Mercado Pago on its hosted page. Without this entry
+        // the router rejects wallet payments before reaching the connector
+        // (validate_connector_against_payment_request).
+        supported_payment_methods.add(
+            enums::PaymentMethod::Wallet,
+            enums::PaymentMethodType::MercadoPago,
+            PaymentMethodDetails {
+                mandates: enums::FeatureStatus::NotSupported,
+                refunds: enums::FeatureStatus::Supported,
+                supported_capture_methods: vec![enums::CaptureMethod::Automatic],
+                specific_features: None,
+            },
+        );
+
         supported_payment_methods
     });
 
@@ -1111,10 +1168,8 @@ static MERCADOPAGO_CONNECTOR_INFO: ConnectorInfo = ConnectorInfo {
     integration_status: enums::ConnectorIntegrationStatus::Sandbox,
 };
 
-static MERCADOPAGO_SUPPORTED_WEBHOOK_FLOWS: [enums::EventClass; 2] = [
-    enums::EventClass::Payments,
-    enums::EventClass::Refunds,
-];
+static MERCADOPAGO_SUPPORTED_WEBHOOK_FLOWS: [enums::EventClass; 2] =
+    [enums::EventClass::Payments, enums::EventClass::Refunds];
 
 impl ConnectorSpecifications for Mercadopago {
     fn get_connector_about(&self) -> Option<&'static ConnectorInfo> {

--- a/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mercadopago/transformers.rs
@@ -1,15 +1,20 @@
+use std::collections::HashMap;
+
 use common_enums::enums;
-use common_utils::{pii::SecretSerdeValue, types::FloatMajorUnit};
+use common_utils::{pii::SecretSerdeValue, request::Method, types::FloatMajorUnit};
 use hyperswitch_domain_models::{
-    payment_method_data::PaymentMethodData,
+    payment_method_data::{PaymentMethodData, WalletData},
     router_data::{ConnectorAuthType, ErrorResponse, RouterData},
     router_flow_types::{
         payments::PaymentMethodToken,
         refunds::{Execute, RSync},
     },
     router_request_types::ResponseId,
-    router_response_types::{PaymentsResponseData, RefundsResponseData},
-    types::{PaymentsAuthorizeRouterData, PaymentsCaptureRouterData, RefundsRouterData, TokenizationRouterData},
+    router_response_types::{PaymentsResponseData, RedirectForm, RefundsResponseData},
+    types::{
+        PaymentsAuthorizeRouterData, PaymentsCaptureRouterData, RefundsRouterData,
+        TokenizationRouterData,
+    },
 };
 use hyperswitch_interfaces::errors;
 use masking::{PeekInterface, Secret};
@@ -106,6 +111,22 @@ pub struct MercadopagoMetadata {
     /// Marketplace commission — absolute amount in the transaction currency
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application_fee: Option<f64>,
+    /// Checkout Pro (hosted checkout) options
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkout_pro: Option<MercadopagoCheckoutProOptions>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct MercadopagoCheckoutProOptions {
+    /// true = approve/reject only, no intermediate states (disables offline methods)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_mode: Option<bool>,
+    /// Maximum installments offered in the hosted checkout
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installments: Option<i32>,
+    /// Payment types to exclude in the hosted checkout (e.g. "ticket" for cash)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excluded_payment_types: Option<Vec<String>>,
 }
 
 impl TryFrom<&Option<SecretSerdeValue>> for MercadopagoMetadata {
@@ -114,8 +135,12 @@ impl TryFrom<&Option<SecretSerdeValue>> for MercadopagoMetadata {
         match meta_data {
             Some(metadata) => {
                 let json_value = metadata.peek().clone();
-                serde_json::from_value::<Self>(json_value)
-                    .map_err(|_| errors::ConnectorError::InvalidConnectorConfig { config: "frm_metadata" }.into())
+                serde_json::from_value::<Self>(json_value).map_err(|_| {
+                    errors::ConnectorError::InvalidConnectorConfig {
+                        config: "frm_metadata",
+                    }
+                    .into()
+                })
             }
             None => Ok(Self::default()),
         }
@@ -126,8 +151,9 @@ impl TryFrom<&Option<serde_json::Value>> for MercadopagoMetadata {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(meta_data: &Option<serde_json::Value>) -> Result<Self, Self::Error> {
         match meta_data {
-            Some(metadata) => serde_json::from_value::<Self>(metadata.clone())
-                .map_err(|_e| errors::ConnectorError::InvalidConnectorConfig { config: "metadata" }.into()),
+            Some(metadata) => serde_json::from_value::<Self>(metadata.clone()).map_err(|_e| {
+                errors::ConnectorError::InvalidConnectorConfig { config: "metadata" }.into()
+            }),
             None => Ok(Self::default()),
         }
     }
@@ -169,20 +195,23 @@ impl TryFrom<&TokenizationRouterData> for MercadopagoTokenRequest {
                 // This is a workaround since PaymentMethodTokenizationData doesn't have metadata field
                 // User should pass MercadoPago metadata in frm_metadata of the payment request
                 let metadata = MercadopagoMetadata::try_from(&item.frm_metadata)?;
-                
+
                 let cardholder_name = card
                     .card_holder_name
                     .clone()
                     .unwrap_or_else(|| Secret::new("APRO".to_string()));
 
                 // Build identification for cardholder if provided in metadata
-                let identification = match (metadata.identification_type, metadata.identification_number) {
-                    (Some(id_type), Some(id_number)) => Some(MercadopagoCardholderIdentification {
-                        id_type,
-                        number: id_number,
-                    }),
-                    _ => None,
-                };
+                let identification =
+                    match (metadata.identification_type, metadata.identification_number) {
+                        (Some(id_type), Some(id_number)) => {
+                            Some(MercadopagoCardholderIdentification {
+                                id_type,
+                                number: id_number,
+                            })
+                        }
+                        _ => None,
+                    };
 
                 Ok(Self {
                     card_number: card.card_number.clone(),
@@ -380,11 +409,12 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
         };
 
         // payment_method_id is required
-        let payment_method_id = metadata
-            .payment_method_id
-            .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "metadata.payment_method_id",
-            })?;
+        let payment_method_id =
+            metadata
+                .payment_method_id
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "metadata.payment_method_id",
+                })?;
 
         let issuer_id = metadata
             .issuer_id
@@ -429,7 +459,10 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
             .cloned();
 
         // Build payer identification from metadata
-        let payer_identification = match (&metadata.identification_type, &metadata.identification_number) {
+        let payer_identification = match (
+            &metadata.identification_type,
+            &metadata.identification_number,
+        ) {
             (Some(id_type), Some(id_number)) => Some(MercadopagoIdentification {
                 id_type: Some(id_type.clone()),
                 number: Some(id_number.clone()),
@@ -443,23 +476,28 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
             let has_item_info = metadata.item.is_some();
 
             if has_payer_info || has_item_info {
-                let additional_payer = metadata.payer.as_ref().map(|p| {
-                    MercadopagoAdditionalInfoPayer {
-                        first_name: p.first_name.as_ref().map(|s| s.peek().to_string()),
-                        last_name: p.last_name.as_ref().map(|s| s.peek().to_string()),
-                        phone: p.phone.as_ref().map(|ph| MercadopagoAdditionalInfoPayerPhone {
-                            number: Some(ph.peek().to_string()),
-                        }),
-                        address: if p.address.is_some() || p.zip_code.is_some() {
-                            Some(MercadopagoAdditionalInfoPayerAddress {
-                                street_name: p.address.as_ref().map(|s| s.peek().to_string()),
-                                zip_code: p.zip_code.as_ref().map(|s| s.peek().to_string()),
-                            })
-                        } else {
-                            None
-                        },
-                    }
-                });
+                let additional_payer =
+                    metadata
+                        .payer
+                        .as_ref()
+                        .map(|p| MercadopagoAdditionalInfoPayer {
+                            first_name: p.first_name.as_ref().map(|s| s.peek().to_string()),
+                            last_name: p.last_name.as_ref().map(|s| s.peek().to_string()),
+                            phone: p
+                                .phone
+                                .as_ref()
+                                .map(|ph| MercadopagoAdditionalInfoPayerPhone {
+                                    number: Some(ph.peek().to_string()),
+                                }),
+                            address: if p.address.is_some() || p.zip_code.is_some() {
+                                Some(MercadopagoAdditionalInfoPayerAddress {
+                                    street_name: p.address.as_ref().map(|s| s.peek().to_string()),
+                                    zip_code: p.zip_code.as_ref().map(|s| s.peek().to_string()),
+                                })
+                            } else {
+                                None
+                            },
+                        });
 
                 let category_descriptor = metadata.payer.as_ref().and_then(|p| {
                     if p.first_name.is_some() || p.last_name.is_some() {
@@ -504,7 +542,8 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
                 let max_fee = amount_f64 * MAX_APPLICATION_FEE_RATIO;
                 if fee > max_fee {
                     return Err(errors::ConnectorError::InvalidDataFormat {
-                        field_name: "application_fee exceeds maximum allowed (0.7% of transaction_amount)",
+                        field_name:
+                            "application_fee exceeds maximum allowed (0.7% of transaction_amount)",
                     }
                     .into());
                 }
@@ -537,6 +576,274 @@ impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for Mercadopa
     }
 }
 
+// ============================================================================
+// Checkout Pro - POST /checkout/preferences (hosted checkout redirect)
+// ============================================================================
+
+/// Mercado Pago rejects non-public hosts in `back_urls` and `notification_url`.
+/// Parses the host (instead of substring-matching the whole URL) so legitimate
+/// URLs like `https://shop.com/return?next=localhost` are not dropped.
+pub(crate) fn filter_public_url(url: Option<&String>) -> Option<String> {
+    let candidate = url?;
+    let parsed = url::Url::parse(candidate).ok()?;
+    let is_local = match parsed.host()? {
+        url::Host::Domain(domain) => {
+            let domain = domain.to_ascii_lowercase();
+            domain == "localhost"
+                || domain.ends_with(".localhost")
+                || domain == "host.docker.internal"
+        }
+        url::Host::Ipv4(ip) => ip.is_loopback() || ip.is_unspecified() || ip.is_private(),
+        url::Host::Ipv6(ip) => ip.is_loopback() || ip.is_unspecified(),
+    };
+
+    if is_local {
+        router_env::logger::warn!(
+            "mercadopago: dropping non-public URL from the preference payload"
+        );
+        None
+    } else {
+        Some(candidate.clone())
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoPreferenceItem {
+    pub id: String,
+    pub title: String,
+    pub quantity: i32,
+    pub unit_price: FloatMajorUnit,
+    pub currency_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoBackUrls {
+    pub success: String,
+    pub pending: String,
+    pub failure: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoExcludedPaymentType {
+    pub id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoPreferencePaymentMethods {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installments: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excluded_payment_types: Option<Vec<MercadopagoExcludedPaymentType>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoPreferencePayer {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surname: Option<Secret<String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MercadopagoPreferenceRequest {
+    pub items: Vec<MercadopagoPreferenceItem>,
+    pub external_reference: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payer: Option<MercadopagoPreferencePayer>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub back_urls: Option<MercadopagoBackUrls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_return: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notification_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statement_descriptor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_mode: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_methods: Option<MercadopagoPreferencePaymentMethods>,
+    /// Marketplace commission for OAuth-connected sellers (preferences use
+    /// `marketplace_fee`, unlike direct payments which use `application_fee`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub marketplace_fee: Option<f64>,
+}
+
+impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>>
+    for MercadopagoPreferenceRequest
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: &MercadopagoRouterData<&PaymentsAuthorizeRouterData>,
+    ) -> Result<Self, Self::Error> {
+        let router_data = item.router_data;
+
+        // Checkout Pro auto-captures inside Mercado Pago: manual capture cannot work.
+        if matches!(
+            router_data.request.capture_method,
+            Some(enums::CaptureMethod::Manual) | Some(enums::CaptureMethod::ManualMultiple)
+        ) {
+            return Err(errors::ConnectorError::NotImplemented(
+                "manual capture for Mercado Pago Checkout Pro".to_string(),
+            )
+            .into());
+        }
+
+        // Merge metadata: request.metadata first, frm_metadata as per-field fallback
+        // (api2 sends the marketplace fee through frm_metadata, like the card flow).
+        let meta_request = MercadopagoMetadata::try_from(&router_data.request.metadata)?;
+        let meta_frm = MercadopagoMetadata::try_from(&router_data.frm_metadata)?;
+        let checkout_pro = meta_request
+            .checkout_pro
+            .or(meta_frm.checkout_pro)
+            .unwrap_or_default();
+        let application_fee = meta_request.application_fee.or(meta_frm.application_fee);
+        let item_info = meta_request.item.or(meta_frm.item);
+
+        let unit_price = item.amount;
+
+        let marketplace_fee = match application_fee {
+            Some(fee) if fee > 0.0 => {
+                let amount_f64 = unit_price.get_amount_as_f64();
+                let max_fee = amount_f64 * MAX_APPLICATION_FEE_RATIO;
+                if fee > max_fee {
+                    return Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name:
+                            "application_fee exceeds maximum allowed (0.7% of transaction_amount)",
+                    }
+                    .into());
+                }
+                Some(fee)
+            }
+            _ => None,
+        };
+
+        let title = item_info
+            .as_ref()
+            .and_then(|i| i.title.clone())
+            .or_else(|| router_data.description.clone())
+            .unwrap_or_else(|| "Pago".to_string());
+
+        // The buyer returns to Hyperswitch's own redirect-response endpoint
+        // (router_return_url), which triggers PSync and only then forwards to the
+        // merchant's return_url. Mercado Pago rejects localhost back_urls, so in
+        // that case the preference is created without them (webhook/PSync only).
+        let back_urls =
+            filter_public_url(router_data.request.router_return_url.as_ref()).map(|return_url| {
+                MercadopagoBackUrls {
+                    success: return_url.clone(),
+                    pending: return_url.clone(),
+                    failure: return_url,
+                }
+            });
+        let auto_return = back_urls.as_ref().map(|_| "approved".to_string());
+
+        let notification_url = filter_public_url(router_data.request.webhook_url.as_ref());
+
+        let payer_email = router_data
+            .request
+            .email
+            .as_ref()
+            .map(|e| e.peek().to_string())
+            .or_else(|| {
+                router_data
+                    .get_optional_billing_email()
+                    .map(|e| e.peek().to_string())
+            });
+        let payer_name = router_data
+            .get_optional_billing_first_name()
+            .map(|n| n.peek().to_string());
+        let payer_surname = router_data
+            .get_optional_billing_last_name()
+            .map(|n| n.peek().to_string());
+        let payer = if payer_email.is_some() || payer_name.is_some() || payer_surname.is_some() {
+            Some(MercadopagoPreferencePayer {
+                email: payer_email.map(Secret::new),
+                name: payer_name.map(Secret::new),
+                surname: payer_surname.map(Secret::new),
+            })
+        } else {
+            None
+        };
+
+        let excluded_payment_types = checkout_pro.excluded_payment_types.as_ref().map(|types| {
+            types
+                .iter()
+                .map(|id| MercadopagoExcludedPaymentType { id: id.clone() })
+                .collect::<Vec<_>>()
+        });
+        let payment_methods =
+            if checkout_pro.installments.is_some() || excluded_payment_types.is_some() {
+                Some(MercadopagoPreferencePaymentMethods {
+                    installments: checkout_pro.installments,
+                    excluded_payment_types,
+                })
+            } else {
+                None
+            };
+
+        Ok(Self {
+            items: vec![MercadopagoPreferenceItem {
+                id: router_data.connector_request_reference_id.clone(),
+                title,
+                quantity: 1,
+                unit_price,
+                currency_id: router_data.request.currency.to_string(),
+                category_id: item_info.and_then(|i| i.category_id),
+            }],
+            external_reference: router_data.connector_request_reference_id.clone(),
+            payer,
+            back_urls,
+            auto_return,
+            notification_url,
+            statement_descriptor: router_data.request.statement_descriptor.clone(),
+            binary_mode: checkout_pro.binary_mode,
+            payment_methods,
+            marketplace_fee,
+        })
+    }
+}
+
+/// Authorize dispatch: Checkout Pro wallet goes to POST /checkout/preferences,
+/// everything else keeps the existing card-token POST /v1/payments path.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum MercadopagoAuthorizeRequest {
+    Preference(Box<MercadopagoPreferenceRequest>),
+    Payment(Box<MercadopagoPaymentsRequest>),
+}
+
+impl MercadopagoAuthorizeRequest {
+    pub fn is_checkout_pro(payment_method_data: &PaymentMethodData) -> bool {
+        matches!(
+            payment_method_data,
+            PaymentMethodData::Wallet(WalletData::MercadoPagoCheckoutPro {})
+        )
+    }
+}
+
+impl TryFrom<&MercadopagoRouterData<&PaymentsAuthorizeRouterData>> for MercadopagoAuthorizeRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: &MercadopagoRouterData<&PaymentsAuthorizeRouterData>,
+    ) -> Result<Self, Self::Error> {
+        if Self::is_checkout_pro(&item.router_data.request.payment_method_data) {
+            Ok(Self::Preference(Box::new(
+                MercadopagoPreferenceRequest::try_from(item)?,
+            )))
+        } else {
+            Ok(Self::Payment(Box::new(
+                MercadopagoPaymentsRequest::try_from(item)?,
+            )))
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct MercadopagoCaptureRequest {
     pub capture: bool,
@@ -547,14 +854,17 @@ pub struct MercadopagoCaptureRequest {
 impl TryFrom<&MercadopagoRouterData<&PaymentsCaptureRouterData>> for MercadopagoCaptureRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
 
-    fn try_from(item: &MercadopagoRouterData<&PaymentsCaptureRouterData>) -> Result<Self, Self::Error> {
+    fn try_from(
+        item: &MercadopagoRouterData<&PaymentsCaptureRouterData>,
+    ) -> Result<Self, Self::Error> {
         let router_data = item.router_data;
-        
-        let transaction_amount = if router_data.request.amount_to_capture != router_data.request.payment_amount {
-            Some(item.amount)
-        } else {
-            None
-        };
+
+        let transaction_amount =
+            if router_data.request.amount_to_capture != router_data.request.payment_amount {
+                Some(item.amount)
+            } else {
+                None
+            };
 
         Ok(Self {
             capture: true,
@@ -684,32 +994,204 @@ impl<F, T> TryFrom<ResponseRouterData<F, MercadopagoPaymentsResponse, T, Payment
     }
 }
 
+// ============================================================================
+// Checkout Pro - Responses (preference on Authorize, search on PSync)
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MercadopagoPreferenceResponse {
+    /// Preference id, format "{collector_id}-{uuid}" — a String, which is what
+    /// disambiguates the untagged enum against payments (id: i64).
+    pub id: String,
+    /// Hosted checkout URL. Required on purpose: a payment response never has it,
+    /// so an untagged match can't confuse the two variants.
+    pub init_point: String,
+    #[serde(default)]
+    pub sandbox_init_point: Option<String>,
+    #[serde(default)]
+    pub external_reference: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MercadopagoAuthorizeResponse {
+    /// `id: i64` + `status` — fails to parse a preference (id is a String there)
+    Payment(MercadopagoPaymentsResponse),
+    /// `id: String` + `init_point` — fails to parse a payment (no init_point)
+    Preference(Box<MercadopagoPreferenceResponse>),
+}
+
+impl<F, T> TryFrom<ResponseRouterData<F, MercadopagoAuthorizeResponse, T, PaymentsResponseData>>
+    for RouterData<F, T, PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<F, MercadopagoAuthorizeResponse, T, PaymentsResponseData>,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            MercadopagoAuthorizeResponse::Payment(payment) => Self::try_from(ResponseRouterData {
+                response: payment,
+                data: item.data,
+                http_code: item.http_code,
+            }),
+            MercadopagoAuthorizeResponse::Preference(preference) => {
+                // The MP payment does not exist until the buyer pays on the hosted
+                // page: no transaction id yet. PSync finds it by external_reference
+                // and its resource_id promotion persists the real id on the attempt.
+                let redirection_data = RedirectForm::Form {
+                    endpoint: preference.init_point.clone(),
+                    method: Method::Get,
+                    form_fields: HashMap::new(),
+                };
+
+                Ok(Self {
+                    status: enums::AttemptStatus::AuthenticationPending,
+                    response: Ok(PaymentsResponseData::TransactionResponse {
+                        resource_id: ResponseId::NoResponseId,
+                        redirection_data: Box::new(Some(redirection_data)),
+                        mandate_reference: Box::new(None),
+                        connector_metadata: Some(
+                            serde_json::json!({ "preference_id": preference.id }),
+                        ),
+                        network_txn_id: None,
+                        connector_response_reference_id: preference
+                            .external_reference
+                            .clone()
+                            .or(Some(preference.id.clone())),
+                        incremental_authorization_allowed: None,
+                        charges: None,
+                    }),
+                    ..item.data
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MercadopagoSearchResponse {
+    /// DELIBERATELY required (no serde default): with a default, a single-payment
+    /// response would deserialize as `Search { results: [] }` and every PSync
+    /// would silently report "buyer hasn't paid yet".
+    pub results: Vec<MercadopagoPaymentsResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MercadopagoPSyncResponse {
+    /// Must stay FIRST: `results` is required, so a payment body falls through,
+    /// while `{"results": [], ...}` (buyer hasn't paid) matches here.
+    Search(MercadopagoSearchResponse),
+    Payment(MercadopagoPaymentsResponse),
+}
+
+impl<F, T> TryFrom<ResponseRouterData<F, MercadopagoPSyncResponse, T, PaymentsResponseData>>
+    for RouterData<F, T, PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<F, MercadopagoPSyncResponse, T, PaymentsResponseData>,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            MercadopagoPSyncResponse::Payment(payment) => Self::try_from(ResponseRouterData {
+                response: payment,
+                data: item.data,
+                http_code: item.http_code,
+            }),
+            MercadopagoPSyncResponse::Search(search) => {
+                // Promotion path (Checkout Pro attempt without a transaction id):
+                // the search runs over OUR external_reference — never over ids taken
+                // from the redirect query string, which the buyer controls. Results
+                // come sorted by date_created desc, so first = most recent.
+                match search.results.into_iter().next() {
+                    // Never promote (nor hard-fail on) a rejected/cancelled payment
+                    // while the hosted session can still be retried: the buyer may
+                    // pay again on the same preference, and a terminal Failure here
+                    // would lose that second payment and block future syncs
+                    // (check_force_psync_precondition excludes Failure).
+                    Some(payment)
+                        if matches!(
+                            payment.status,
+                            MercadopagoPaymentStatus::Rejected
+                                | MercadopagoPaymentStatus::Cancelled
+                        ) =>
+                    {
+                        Ok(keep_waiting_for_buyer(item.data))
+                    }
+                    Some(payment) => Self::try_from(ResponseRouterData {
+                        response: payment,
+                        data: item.data,
+                        http_code: item.http_code,
+                    }),
+                    // Empty search = the buyer hasn't paid yet.
+                    None => Ok(keep_waiting_for_buyer(item.data)),
+                }
+            }
+        }
+    }
+}
+
+/// Sync outcome for a Checkout Pro attempt whose payment is not (yet) usable:
+/// preserves the current attempt status — asserting a fixed status here could
+/// resurrect an attempt that already failed for other reasons.
+fn keep_waiting_for_buyer<F, T>(
+    data: RouterData<F, T, PaymentsResponseData>,
+) -> RouterData<F, T, PaymentsResponseData> {
+    RouterData {
+        response: Ok(PaymentsResponseData::TransactionResponse {
+            resource_id: ResponseId::NoResponseId,
+            redirection_data: Box::new(None),
+            mandate_reference: Box::new(None),
+            connector_metadata: None,
+            network_txn_id: None,
+            connector_response_reference_id: None,
+            incremental_authorization_allowed: None,
+            charges: None,
+        }),
+        ..data
+    }
+}
+
 fn get_mercadopago_error_message(status_detail: &str) -> String {
     match status_detail {
         // Card rejections - bad filled data
         "cc_rejected_bad_filled_card_number" => "The card number is incorrect".to_string(),
         "cc_rejected_bad_filled_date" => "The expiration date is incorrect".to_string(),
         "cc_rejected_bad_filled_other" => "Some card detail is incorrect".to_string(),
-        "cc_rejected_bad_filled_security_code" => "The security code (CVV) is incorrect".to_string(),
+        "cc_rejected_bad_filled_security_code" => {
+            "The security code (CVV) is incorrect".to_string()
+        }
 
         // Card rejections - card issues
         "cc_rejected_blacklist" => "The card is blocked".to_string(),
-        "cc_rejected_call_for_authorize" => "The payment requires authorization - call your bank".to_string(),
+        "cc_rejected_call_for_authorize" => {
+            "The payment requires authorization - call your bank".to_string()
+        }
         "cc_rejected_card_disabled" => "The card is disabled - contact your bank".to_string(),
         "cc_rejected_card_error" => "The card could not be processed".to_string(),
-        "cc_rejected_card_type_not_allowed" => "This card type is not allowed for this payment".to_string(),
+        "cc_rejected_card_type_not_allowed" => {
+            "This card type is not allowed for this payment".to_string()
+        }
 
         // Card rejections - transaction issues
         "cc_rejected_duplicated_payment" => "This payment has already been processed".to_string(),
         "cc_rejected_high_risk" => "The payment was rejected due to high risk".to_string(),
         "cc_rejected_insufficient_amount" => "Insufficient funds".to_string(),
-        "cc_rejected_invalid_installments" => "Invalid number of installments for this card".to_string(),
-        "cc_rejected_max_attempts" => "Maximum retry attempts reached - try with another card".to_string(),
+        "cc_rejected_invalid_installments" => {
+            "Invalid number of installments for this card".to_string()
+        }
+        "cc_rejected_max_attempts" => {
+            "Maximum retry attempts reached - try with another card".to_string()
+        }
         "cc_rejected_other_reason" => "The payment was rejected by the card issuer".to_string(),
 
         // 3DS rejections
         "cc_rejected_3ds_challenge" => "Payment rejected for not passing 3DS challenge".to_string(),
-        "cc_rejected_3ds_mandatory" => "3DS authentication is mandatory for this payment".to_string(),
+        "cc_rejected_3ds_mandatory" => {
+            "3DS authentication is mandatory for this payment".to_string()
+        }
 
         // Amount/limit rejections
         "cc_amount_rate_limit_exceeded" => "Amount exceeds the allowed rate limit".to_string(),
@@ -753,44 +1235,44 @@ fn get_mercadopago_error_message(status_detail: &str) -> String {
 /// Get a descriptive error message for API validation errors (HTTP 400)
 fn get_api_validation_error_message(error_code: &str, cause_code: Option<&str>) -> String {
     match error_code {
-        "bad_request" => {
-            match cause_code {
-                Some("1") | Some("3") => "Invalid or missing parameters in the request".to_string(),
-                Some("2") => "Invalid token - the card token may have expired or is invalid".to_string(),
-                Some("4") => "Invalid customer data".to_string(),
-                Some("5") => "Invalid card data".to_string(),
-                Some("6") => "Invalid security code".to_string(),
-                Some("7") => "Invalid expiration date".to_string(),
-                Some("8") => "Invalid card number".to_string(),
-                Some("105") => "User not found or invalid user".to_string(),
-                Some("106") => "Card token not found or expired".to_string(),
-                Some("107") => "Card not found".to_string(),
-                Some("109") => "Invalid card expiration date".to_string(),
-                Some("145") => "User ID is required".to_string(),
-                Some("150") => "Payer email must be different from collector email".to_string(),
-                Some("151") => "Payer ID must be different from collector ID".to_string(),
-                Some("160") => "Card issuer not found".to_string(),
-                Some("200") => "Invalid amount".to_string(),
-                Some("205") | Some("E205") => "Card number is required".to_string(),
-                Some("208") | Some("E208") => "Card expiration month is required".to_string(),
-                Some("209") | Some("E209") => "Card expiration year is required".to_string(),
-                Some("212") | Some("E212") => "Card type is required".to_string(),
-                Some("213") | Some("E213") => "Document type is required".to_string(),
-                Some("214") | Some("E214") => "Document number is required".to_string(),
-                Some("220") | Some("E220") => "Card issuer is required".to_string(),
-                Some("221") | Some("E221") => "Invalid card number".to_string(),
-                Some("224") | Some("E224") => "Security code is required".to_string(),
-                Some("E301") => "Invalid card number".to_string(),
-                Some("E302") => "Invalid security code".to_string(),
-                Some("316") => "Cardholder name is required".to_string(),
-                Some("322") => "Invalid document type".to_string(),
-                Some("323") => "Invalid document number".to_string(),
-                Some("324") => "Invalid document subtype".to_string(),
-                Some("325") => "Invalid document number for the document type".to_string(),
-                Some("326") => "Invalid document type for the country".to_string(),
-                _ => "Invalid request parameters".to_string(),
+        "bad_request" => match cause_code {
+            Some("1") | Some("3") => "Invalid or missing parameters in the request".to_string(),
+            Some("2") => {
+                "Invalid token - the card token may have expired or is invalid".to_string()
             }
-        }
+            Some("4") => "Invalid customer data".to_string(),
+            Some("5") => "Invalid card data".to_string(),
+            Some("6") => "Invalid security code".to_string(),
+            Some("7") => "Invalid expiration date".to_string(),
+            Some("8") => "Invalid card number".to_string(),
+            Some("105") => "User not found or invalid user".to_string(),
+            Some("106") => "Card token not found or expired".to_string(),
+            Some("107") => "Card not found".to_string(),
+            Some("109") => "Invalid card expiration date".to_string(),
+            Some("145") => "User ID is required".to_string(),
+            Some("150") => "Payer email must be different from collector email".to_string(),
+            Some("151") => "Payer ID must be different from collector ID".to_string(),
+            Some("160") => "Card issuer not found".to_string(),
+            Some("200") => "Invalid amount".to_string(),
+            Some("205") | Some("E205") => "Card number is required".to_string(),
+            Some("208") | Some("E208") => "Card expiration month is required".to_string(),
+            Some("209") | Some("E209") => "Card expiration year is required".to_string(),
+            Some("212") | Some("E212") => "Card type is required".to_string(),
+            Some("213") | Some("E213") => "Document type is required".to_string(),
+            Some("214") | Some("E214") => "Document number is required".to_string(),
+            Some("220") | Some("E220") => "Card issuer is required".to_string(),
+            Some("221") | Some("E221") => "Invalid card number".to_string(),
+            Some("224") | Some("E224") => "Security code is required".to_string(),
+            Some("E301") => "Invalid card number".to_string(),
+            Some("E302") => "Invalid security code".to_string(),
+            Some("316") => "Cardholder name is required".to_string(),
+            Some("322") => "Invalid document type".to_string(),
+            Some("323") => "Invalid document number".to_string(),
+            Some("324") => "Invalid document subtype".to_string(),
+            Some("325") => "Invalid document number for the document type".to_string(),
+            Some("326") => "Invalid document type for the country".to_string(),
+            _ => "Invalid request parameters".to_string(),
+        },
         "invalid_token" => "The card token is invalid or has expired".to_string(),
         "invalid_card_expiration_month" => "Invalid card expiration month".to_string(),
         "invalid_card_expiration_year" => "Invalid card expiration year".to_string(),
@@ -958,20 +1440,21 @@ impl MercadopagoErrorResponse {
     }
 
     pub fn get_detailed_reason(&self) -> Option<String> {
-        self.cause.as_ref().map(|causes| {
-            causes
-                .iter()
-                .filter_map(|c| {
-                    match (&c.code, &c.description) {
+        self.cause
+            .as_ref()
+            .map(|causes| {
+                causes
+                    .iter()
+                    .filter_map(|c| match (&c.code, &c.description) {
                         (Some(code), Some(desc)) => Some(format!("Code {}: {}", code, desc)),
                         (Some(code), None) => Some(format!("Code {}", code)),
                         (None, Some(desc)) => Some(desc.clone()),
                         (None, None) => None,
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("; ")
-        }).filter(|s| !s.is_empty())
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            })
+            .filter(|s| !s.is_empty())
     }
 }
 
@@ -1036,7 +1519,10 @@ impl MercadopagoWebhookBodyEnum {
         match self {
             Self::Full(body) => MercadopagoWebhookResourceObject {
                 resource_id: body.data.id.clone(),
-                topic: body.webhook_type.clone().unwrap_or_else(|| "payment".to_string()),
+                topic: body
+                    .webhook_type
+                    .clone()
+                    .unwrap_or_else(|| "payment".to_string()),
                 action: Some(body.action.clone()),
             },
             Self::Feed(body) => MercadopagoWebhookResourceObject {
@@ -1113,10 +1599,10 @@ impl From<MercadopagoWebhookAction> for api_models::webhooks::IncomingWebhookEve
         // For refunds, since IncomingWebhookEvent doesn't have a RefundProcessing variant,
         // we map to EventNotSupported. Refund status is updated via periodic sync (RSync) calls.
         match action {
-            MercadopagoWebhookAction::PaymentCreated
-            | MercadopagoWebhookAction::PaymentUpdated => Self::PaymentIntentProcessing,
-            MercadopagoWebhookAction::RefundCreated
-            | MercadopagoWebhookAction::RefundUpdated => {
+            MercadopagoWebhookAction::PaymentCreated | MercadopagoWebhookAction::PaymentUpdated => {
+                Self::PaymentIntentProcessing
+            }
+            MercadopagoWebhookAction::RefundCreated | MercadopagoWebhookAction::RefundUpdated => {
                 // MercadoPago webhook payloads only contain the resource ID (no status).
                 // Since there is no RefundProcessing event variant, refund status changes
                 // are NOT tracked via webhooks. Refund state is updated exclusively through
@@ -1128,5 +1614,98 @@ impl From<MercadopagoWebhookAction> for api_models::webhooks::IncomingWebhookEve
             | MercadopagoWebhookAction::ChargebackUpdated => Self::DisputeOpened,
             MercadopagoWebhookAction::Unknown => Self::EventNotSupported,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAYMENT_JSON: &str = r#"{
+        "id": 123456789,
+        "status": "approved",
+        "status_detail": "accredited",
+        "external_reference": "pay_abc_1",
+        "transaction_amount": 100.5
+    }"#;
+
+    const PREFERENCE_JSON: &str = r#"{
+        "id": "1963547549-6b18effb-eeba-4daa-9c57-6c916c8f1775",
+        "init_point": "https://www.mercadopago.com.ar/checkout/v1/redirect?pref_id=x",
+        "sandbox_init_point": "https://sandbox.mercadopago.com.ar/checkout/v1/redirect?pref_id=x",
+        "external_reference": "pay_abc_1"
+    }"#;
+
+    #[test]
+    fn authorize_response_discriminates_payment_from_preference() {
+        let payment: MercadopagoAuthorizeResponse = serde_json::from_str(PAYMENT_JSON).unwrap();
+        assert!(matches!(payment, MercadopagoAuthorizeResponse::Payment(p) if p.id == 123456789));
+
+        let preference: MercadopagoAuthorizeResponse =
+            serde_json::from_str(PREFERENCE_JSON).unwrap();
+        match preference {
+            MercadopagoAuthorizeResponse::Preference(p) => {
+                assert!(p.init_point.contains("checkout/v1/redirect"));
+                assert_eq!(p.external_reference.as_deref(), Some("pay_abc_1"));
+            }
+            MercadopagoAuthorizeResponse::Payment(_) => {
+                panic!("preference response must not parse as payment")
+            }
+        }
+    }
+
+    #[test]
+    fn psync_response_single_payment_is_not_swallowed_by_search_variant() {
+        // Guard for the serde trap: `results` must stay required, otherwise this
+        // payment body would deserialize as Search { results: [] }.
+        let parsed: MercadopagoPSyncResponse = serde_json::from_str(PAYMENT_JSON).unwrap();
+        assert!(matches!(parsed, MercadopagoPSyncResponse::Payment(p) if p.id == 123456789));
+    }
+
+    #[test]
+    fn psync_response_search_variants() {
+        let empty: MercadopagoPSyncResponse =
+            serde_json::from_str(r#"{"results": [], "paging": {"total": 0}}"#).unwrap();
+        assert!(matches!(empty, MercadopagoPSyncResponse::Search(s) if s.results.is_empty()));
+
+        let with_result: MercadopagoPSyncResponse = serde_json::from_str(&format!(
+            r#"{{"results": [{PAYMENT_JSON}], "paging": {{"total": 1}}}}"#
+        ))
+        .unwrap();
+        assert!(matches!(with_result, MercadopagoPSyncResponse::Search(s) if s.results.len() == 1));
+    }
+
+    #[test]
+    fn filter_public_url_drops_local_hosts() {
+        for local in [
+            "http://localhost:8080/return",
+            "http://sub.localhost/return",
+            "http://127.0.0.1/return",
+            "http://127.5.5.5/return",
+            "http://[::1]/return",
+            "http://0.0.0.0/return",
+            "http://10.0.0.5/return",
+            "http://192.168.1.10/return",
+            "http://host.docker.internal:8080/return",
+            "not a url",
+        ] {
+            assert_eq!(filter_public_url(Some(&local.to_string())), None, "{local}");
+        }
+
+        // Host parsing, not substring matching: these are legitimate public URLs.
+        for public in [
+            "https://pxsol.com/return",
+            "https://shop.com/return?next=localhost",
+            "https://mylocalhost.shop/return",
+            "https://declensional-moira-bruno.ngrok-free.dev/payments/x/y/redirect/response/mercadopago",
+        ] {
+            assert_eq!(
+                filter_public_url(Some(&public.to_string())),
+                Some(public.to_string()),
+                "{public}"
+            );
+        }
+
+        assert_eq!(filter_public_url(None), None);
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/mifinity/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mifinity/transformers.rs
@@ -191,10 +191,13 @@ impl TryFrom<&MifinityRouterData<&types::PaymentsAuthorizeRouterData>> for Mifin
                 | WalletData::CashappQr(_)
                 | WalletData::SwishQr(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Mifinity"),
-                )
-                .into()),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Mifinity"),
+                    )
+                    .into())
+                }
             },
             PaymentMethodData::Card(_)
             | PaymentMethodData::CardRedirect(_)

--- a/crates/hyperswitch_connectors/src/connectors/multisafepay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/multisafepay/transformers.rs
@@ -552,9 +552,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("multisafepay"),
+                    ))?
+                }
             },
             PaymentMethodData::BankRedirect(ref bank_data) => match bank_data {
                 BankRedirectData::Giropay { .. } => Type::Redirect,
@@ -624,9 +627,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("multisafepay"),
+                    ))?
+                }
             }),
             PaymentMethodData::BankRedirect(ref bank_data) => Some(match bank_data {
                 BankRedirectData::Giropay { .. } => Gateway::Giropay,
@@ -803,9 +809,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("multisafepay"),
+                    ))?
+                }
             },
             PaymentMethodData::PayLater(ref paylater) => {
                 Some(GatewayInfo::PayLater(PayLaterInfo {

--- a/crates/hyperswitch_connectors/src/connectors/nexinets/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nexinets/transformers.rs
@@ -735,7 +735,8 @@ fn get_wallet_details(
         | WalletData::SwishQr(_)
         | WalletData::Mifinity(_)
         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+        | WalletData::MercadoPagoSdk(_)
+        | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("nexinets"),
         ))?,
     }

--- a/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
@@ -650,9 +650,12 @@ impl TryFrom<(&PaymentMethodData, Option<&PaymentsAuthorizeRouterData>)> for Pay
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(report!(ConnectorError::NotImplemented(
-                    get_unimplemented_payment_method_error_message("nmi"),
-                ))),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(report!(ConnectorError::NotImplemented(
+                        get_unimplemented_payment_method_error_message("nmi"),
+                    )))
+                }
             },
             PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::PayLater(_)

--- a/crates/hyperswitch_connectors/src/connectors/noon/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/noon/transformers.rs
@@ -351,9 +351,12 @@ impl TryFrom<&NoonRouterData<&PaymentsAuthorizeRouterData>> for NoonPaymentsRequ
                         | WalletData::SwishQr(_)
                         | WalletData::Mifinity(_)
                         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                            utils::get_unimplemented_payment_method_error_message("Noon"),
-                        )),
+                        | WalletData::MercadoPagoSdk(_)
+                        | WalletData::MercadoPagoCheckoutPro {} => {
+                            Err(errors::ConnectorError::NotImplemented(
+                                utils::get_unimplemented_payment_method_error_message("Noon"),
+                            ))
+                        }
                     },
                     PaymentMethodData::CardRedirect(_)
                     | PaymentMethodData::PayLater(_)

--- a/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
@@ -410,7 +410,8 @@ impl TryFrom<&NovalnetRouterData<&PaymentsAuthorizeRouterData>> for NovalnetPaym
                     | WalletDataPaymentMethod::SwishQr(_)
                     | WalletDataPaymentMethod::WeChatPayQr(_)
                     | WalletDataPaymentMethod::Mifinity(_)
-                    | WalletDataPaymentMethod::MercadoPagoSdk(_) => {
+                    | WalletDataPaymentMethod::MercadoPagoSdk(_)
+                    | WalletDataPaymentMethod::MercadoPagoCheckoutPro {} => {
                         Err(errors::ConnectorError::NotImplemented(
                             utils::get_unimplemented_payment_method_error_message("novalnet"),
                         )
@@ -1676,7 +1677,8 @@ impl TryFrom<&SetupMandateRouterData> for NovalnetPaymentsRequest {
                 | WalletDataPaymentMethod::SwishQr(_)
                 | WalletDataPaymentMethod::WeChatPayQr(_)
                 | WalletDataPaymentMethod::Mifinity(_)
-                | WalletDataPaymentMethod::MercadoPagoSdk(_) => {
+                | WalletDataPaymentMethod::MercadoPagoSdk(_)
+                | WalletDataPaymentMethod::MercadoPagoCheckoutPro {} => {
                     Err(errors::ConnectorError::NotImplemented(
                         utils::get_unimplemented_payment_method_error_message("novalnet"),
                     ))?

--- a/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
@@ -1607,10 +1607,13 @@ where
                 | WalletData::WeChatPayQr(_)
                 | WalletData::RevolutPay(_)
                 | WalletData::Mifinity(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("nuvei"),
-                )
-                .into()),
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("nuvei"),
+                    )
+                    .into())
+                }
             },
             PaymentMethodData::BankRedirect(redirect) => match redirect {
                 BankRedirectData::Eps { .. } => Self::foreign_try_from((

--- a/crates/hyperswitch_connectors/src/connectors/payme/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payme/transformers.rs
@@ -433,11 +433,14 @@ impl TryFrom<&PaymentMethodData> for SalePaymentMethod {
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotSupported {
-                    message: "Wallet".to_string(),
-                    connector: "payme",
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotSupported {
+                        message: "Wallet".to_string(),
+                        connector: "payme",
+                    }
+                    .into())
                 }
-                .into()),
             },
             PaymentMethodData::PayLater(_)
             | PaymentMethodData::BankRedirect(_)

--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -1100,9 +1100,12 @@ impl TryFrom<&PaypalRouterData<&PaymentsAuthorizeRouterData>> for PaypalPayments
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
                 | WalletData::Paze(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Paypal"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Paypal"),
+                    ))?
+                }
             },
             PaymentMethodData::BankRedirect(ref bank_redirection_data) => {
                 let bank_redirect_intent = if item.router_data.request.is_auto_capture()? {

--- a/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs
@@ -423,7 +423,8 @@ impl TryFrom<&WalletData> for PaymentMethodType {
             | WalletData::SwishQr(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("Shift4"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/connectors/square/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/square/transformers.rs
@@ -139,9 +139,12 @@ impl TryFrom<(&types::TokenizationRouterData, WalletData)> for SquareTokenReques
             | WalletData::SwishQr(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("Square"),
-            ))?,
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Square"),
+                ))?
+            }
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs
@@ -1211,7 +1211,8 @@ fn get_stripe_payment_method_type_from_wallet_data(
         | WalletData::SwishQr(_)
         | WalletData::WeChatPayRedirect(_)
         | WalletData::Mifinity(_)
-        | WalletData::MercadoPagoSdk(_) => Err(ConnectorError::NotImplemented(
+        | WalletData::MercadoPagoSdk(_)
+        | WalletData::MercadoPagoCheckoutPro {} => Err(ConnectorError::NotImplemented(
             get_unimplemented_payment_method_error_message("stripe"),
         )),
     }
@@ -1691,7 +1692,8 @@ impl TryFrom<(&WalletData, Option<PaymentMethodToken>)> for StripePaymentMethodD
             | WalletData::SwishQr(_)
             | WalletData::WeChatPayRedirect(_)
             | WalletData::Mifinity(_)
-            | WalletData::MercadoPagoSdk(_) => Err(ConnectorError::NotImplemented(
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => Err(ConnectorError::NotImplemented(
                 get_unimplemented_payment_method_error_message("stripe"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
@@ -238,9 +238,12 @@ impl TryFrom<&SetupMandateRouterData> for WellsfargoZeroMandateRequest {
                 | WalletData::SwishQr(_)
                 | WalletData::Mifinity(_)
                 | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Wellsfargo"),
-                ))?,
+                | WalletData::MercadoPagoSdk(_)
+                | WalletData::MercadoPagoCheckoutPro {} => {
+                    Err(errors::ConnectorError::NotImplemented(
+                        utils::get_unimplemented_payment_method_error_message("Wellsfargo"),
+                    ))?
+                }
             },
             PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::PayLater(_)
@@ -1328,10 +1331,13 @@ impl TryFrom<&WellsfargoRouterData<&PaymentsAuthorizeRouterData>> for Wellsfargo
                         | WalletData::SwishQr(_)
                         | WalletData::Mifinity(_)
                         | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                            utils::get_unimplemented_payment_method_error_message("Wellsfargo"),
-                        )
-                        .into()),
+                        | WalletData::MercadoPagoSdk(_)
+                        | WalletData::MercadoPagoCheckoutPro {} => {
+                            Err(errors::ConnectorError::NotImplemented(
+                                utils::get_unimplemented_payment_method_error_message("Wellsfargo"),
+                            )
+                            .into())
+                        }
                     },
                     // If connector_mandate_id is present MandatePayment will be the PMD, the case will be handled in the first `if` clause.
                     // This is a fallback implementation in the event of catastrophe.

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -187,7 +187,8 @@ fn fetch_payment_instrument(
             | WalletData::WeChatPayQr(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("worldpay"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs
@@ -516,9 +516,12 @@ impl
             | WalletData::WeChatPayQr(_)
             | WalletData::Mifinity(_)
             | WalletData::RevolutPay(_)
-                | WalletData::MercadoPagoSdk(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("Zen"),
-            ))?,
+            | WalletData::MercadoPagoSdk(_)
+            | WalletData::MercadoPagoCheckoutPro {} => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Zen"),
+                ))?
+            }
         };
         let terminal_uuid = session_data
             .terminal_uuid

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -5560,6 +5560,7 @@ pub enum PaymentMethodDataType {
     PaypalRedirect,
     PaypalSdk,
     MercadoPagoSdk,
+    MercadoPagoCheckoutPro,
     Paze,
     SamsungPay,
     TwintRedirect,
@@ -5696,6 +5697,9 @@ impl From<PaymentMethodData> for PaymentMethodDataType {
                 payment_method_data::WalletData::PaypalRedirect(_) => Self::PaypalRedirect,
                 payment_method_data::WalletData::PaypalSdk(_) => Self::PaypalSdk,
                 payment_method_data::WalletData::MercadoPagoSdk(_) => Self::MercadoPagoSdk,
+                payment_method_data::WalletData::MercadoPagoCheckoutPro {} => {
+                    Self::MercadoPagoCheckoutPro
+                }
                 payment_method_data::WalletData::Paze(_) => Self::Paze,
                 payment_method_data::WalletData::SamsungPay(_) => Self::SamsungPay,
                 payment_method_data::WalletData::TwintRedirect {} => Self::TwintRedirect,

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -302,6 +302,7 @@ pub enum WalletData {
     PaypalRedirect(PaypalRedirection),
     PaypalSdk(PayPalWalletData),
     MercadoPagoSdk(MercadoPagoSdkData),
+    MercadoPagoCheckoutPro {},
     Paze(PazeWalletData),
     SamsungPay(Box<SamsungPayWalletData>),
     TwintRedirect {},
@@ -1284,6 +1285,9 @@ impl From<api_models::payments::WalletData> for WalletData {
                     device_id: mp_sdk_data.device_id,
                 })
             }
+            api_models::payments::WalletData::MercadoPagoCheckoutPro {} => {
+                Self::MercadoPagoCheckoutPro {}
+            }
             api_models::payments::WalletData::Paze(paze_data) => {
                 Self::Paze(PazeWalletData::from(paze_data))
             }
@@ -2119,7 +2123,9 @@ impl GetPaymentMethodType for WalletData {
             Self::MbWayRedirect(_) => api_enums::PaymentMethodType::MbWay,
             Self::MobilePayRedirect(_) => api_enums::PaymentMethodType::MobilePay,
             Self::PaypalRedirect(_) | Self::PaypalSdk(_) => api_enums::PaymentMethodType::Paypal,
-            Self::MercadoPagoSdk(_) => api_enums::PaymentMethodType::MercadoPago,
+            Self::MercadoPagoSdk(_) | Self::MercadoPagoCheckoutPro {} => {
+                api_enums::PaymentMethodType::MercadoPago
+            }
             Self::Paze(_) => api_enums::PaymentMethodType::Paze,
             Self::SamsungPay(_) => api_enums::PaymentMethodType::SamsungPay,
             Self::TwintRedirect {} => api_enums::PaymentMethodType::Twint,

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -2575,6 +2575,7 @@ pub enum PaymentMethodDataType {
     PaypalRedirect,
     PaypalSdk,
     MercadoPagoSdk,
+    MercadoPagoCheckoutPro,
     Paze,
     SamsungPay,
     TwintRedirect,
@@ -2710,6 +2711,9 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                 domain::payments::WalletData::PaypalRedirect(_) => Self::PaypalRedirect,
                 domain::payments::WalletData::PaypalSdk(_) => Self::PaypalSdk,
                 domain::payments::WalletData::MercadoPagoSdk(_) => Self::MercadoPagoSdk,
+                domain::payments::WalletData::MercadoPagoCheckoutPro {} => {
+                    Self::MercadoPagoCheckoutPro
+                }
                 domain::payments::WalletData::Paze(_) => Self::Paze,
                 domain::payments::WalletData::SamsungPay(_) => Self::SamsungPay,
                 domain::payments::WalletData::TwintRedirect {} => Self::TwintRedirect,


### PR DESCRIPTION
## Qué

Agrega **Mercado Pago Checkout Pro** (hosted checkout / redirect) sobre el connector `mercadopago` existente, reutilizando `PaymentMethodType::MercadoPago`. El comprador es redirigido a la página alojada de MP y paga con wallet, tarjetas, efectivo o cuotas; Hyperswitch resuelve el resultado de forma asíncrona.

## Cómo

- **Variante nueva** `WalletData::MercadoPagoCheckoutPro {}` (fieldless, serde `mercado_pago_checkout_pro`) cableada en api_models, domain_models y los dos `PaymentMethodDataType` de utils. Se agregó el arm `NotImplemented` en cada `match` exhaustivo de `WalletData` de los connectors (28 archivos).
- **Authorize** ramifica según el payment method: wallet → `POST /checkout/preferences` (con `external_reference`, `back_urls = router_return_url`, `auto_return`, `notification_url`, `marketplace_fee` opcional) y devuelve `AuthenticationPending` + `RedirectForm(init_point)` + `NoResponseId`. El flujo de tarjeta existente queda intacto.
- **PSync** promueve el `payment_id` real buscando por `external_reference` (`GET /v1/payments/search`). **No** confía en el `payment_id` del query string del retorno (input controlable por el comprador → sustitución de pagos). Pagos `rejected`/`cancelled` y búsquedas vacías mantienen el attempt esperando, sin fallar terminalmente.
- **ConnectorSpecifications** publica `Wallet/MercadoPago` (solo auto-captura). Dashboard `connector_configs` habilita `[[mercadopago.wallet]]`.
- `filter_public_url` parsea el host (loopback/privadas/localhost); la PII del payer de la preferencia va envuelta en `Secret`.

## Testing

- `cargo check` de `hyperswitch_connectors` y `router` OK.
- 4 tests unitarios nuevos (discriminación de los enums untagged authorize/psync, filtro de URLs públicas).
- **Validado end-to-end en vivo contra Mercado Pago** (dev server): creación de preferencia, redirect, pago aprobado y promoción del `payment_id` vía PSync (`status: succeeded`).

## Notas

- No requiere env vars nuevas: `ROUTER__CONNECTORS__MERCADOPAGO__BASE_URL` ya cubre `/checkout/preferences`. El gate de tokenización debe seguir en `card` (el wallet no tokeniza).
- Webhooks `payment` que lleguen antes de que el PSync promueva el id no correlacionan (el body solo trae `data.id`); mitigado por los reintentos de MP y el force-sync del gateway. Limitación documentada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `WalletData::MercadoPagoCheckoutPro` across API models, domain models, router utilities, and connector utilities.
- Added Mercado Pago Checkout Pro hosted-checkout authorization through preference creation.
- Returned a pending authentication response with a redirect form.
- Added PSync lookup by `external_reference` when no connector transaction ID exists.
- Preserved transaction-ID lookup for other payment flows.
- Added Checkout Pro request and response models, metadata options, response parsing, and marketplace-fee validation.
- Added public URL filtering for redirect and webhook URLs.
- Protected payer PII by limiting payer data sent to Mercado Pago.
- Added Mercado Pago wallet configuration in development, sandbox, and production environments.
- Enabled automatic capture and refunds for the Mercado Pago wallet flow.
- Updated unsupported-wallet matches across other connectors to return existing `NotImplemented` errors.
- Added unit coverage for response handling, PSync search behavior, and URL filtering.
- Validated preference creation, hosted redirect, payment approval, and payment ID promotion in live end-to-end tests.

## Architectural impact

Checkout Pro uses the existing `mercadopago` connector and maps to `PaymentMethodType::MercadoPago`. The authorization path now selects between hosted preference creation and the existing payment endpoint. PSync promotes the real payment after searching by `external_reference`.

The implementation adds no new environment variables. Webhook correlation before PSync promotion remains a documented limitation.

## Security and performance

Public URL filtering blocks local and invalid redirect or webhook URLs. Payer data is restricted to reduce PII exposure. PSync performs an additional Mercado Pago search when the connector transaction ID is unavailable. This adds request overhead only to Checkout Pro synchronization and improves payment correlation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->