### PR TITLE
fix(fiservemea): enmascarar la API Key en los headers, salía en texto plano al log

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
@@ -442,7 +442,15 @@ where
                     .into(),
             ),
             ("Client-Request-Id".to_string(), client_request_id.into()),
-            (headers::API_KEY.to_string(), auth.api_key.expose().into()),
+            // `into_masked()` y no `into()`: el logger imprime el Debug de
+            // `Maskable<String>`, así que un valor sin enmascarar sale en texto plano al
+            // log. La API Key de Fiserv es una credencial y no debe quedar ahí (se
+            // verificó en logs de producción: aparecía completa junto al resto de los
+            // headers, mientras la firma HMAC sí salía enmascarada).
+            (
+                headers::API_KEY.to_string(),
+                auth.api_key.expose().into_masked(),
+            ),
             (headers::TIMESTAMP.to_string(), timestamp.to_string().into()),
             (headers::MESSAGE_SIGNATURE.to_string(), hmac.into_masked()),
         ];


### PR DESCRIPTION
La API Key de Fiserv salía **en texto plano en los logs**. `build_headers` armaba el header
`API-KEY` con `.into()` en lugar de `.into_masked()`, y el logger imprime el `Debug` de
`Maskable<String>` — así que la credencial quedaba completa en el log, junto al resto de los
headers.

Verificado en logs de producción de `pay.mithras.cloud`: la API Key aparecía completa (10
ocurrencias en 2 horas de log), mientras el `Message-Signature` sí salía enmascarado como
`*** alloc::string::String ***`.

```
("Message-Signature", *** alloc::string::String ***), ("API-KEY", "4w7jLv…")
```

## Alcance de la exposición

Sólo la **API Key** (la pública, que viaja en el header). El `api_secret`, que es el que firma el
HMAC, nunca se loggeaba — así que con la key sola no se pueden firmar requests. La exposición es
acotada, pero es una credencial en logs de producción.

## Por qué era un solo lugar

`fiservemea` arma ese header en dos funciones y la otra ya estaba bien:

| | |
|---|---|
| `signed_headers_for_payload` (usada por el 3DS) | ya usaba `.into_masked()` ✅ |
| `build_headers` (todos los demás flujos) | usaba `.into()` ❌ — este es el fix |

Revisé también `payway` y `mercadopago`: todas sus credenciales ya van enmascaradas. Este era el
único caso en los conectores del fork.

## Verificación

- **176/176 tests** de `hyperswitch_connectors`
- **clippy limpio** en fiservemea (`--all-targets`)

## Nota operativa

Conviene rotar la API Key de certificación con Fiserv, porque ya estuvo expuesta en los logs
existentes. Este cambio evita que siga pasando de acá en adelante, pero no borra lo ya loggeado.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Cambios

- `build_headers` ahora aplica `.into_masked()` a la API Key antes de incluirla en el header `API-KEY`.
- `signed_headers_for_payload` ya utilizaba el enmascaramiento.
- Los demás flujos de `fiservemea` conservan su comportamiento.

## Impacto arquitectónico

- El cambio se limita a la construcción de headers del conector `fiservemea`.
- No modifica entidades públicas, contratos de API ni lógica de firma.
- La API Key permanece disponible para las solicitudes, pero no aparece completa en los logs.

## Seguridad

- Se evita la exposición de la API Key en los logs generados por los flujos que usan `build_headers`.
- El `api_secret` no se registraba y no requiere cambios.
- La API Key por sí sola no permite firmar solicitudes.
- Se identificaron 10 apariciones de la credencial en logs de producción.
- Se recomienda rotar la API Key de certificación expuesta en los logs existentes.

## Rendimiento

- `.into_masked()` solo transforma la representación usada en los headers y logs.
- No cambia el número de solicitudes ni el proceso de firma.
- El impacto de rendimiento es mínimo.

## Validación

- `176/176` tests de `hyperswitch_connectors` completados correctamente.
- Clippy completado sin errores para `fiservemea`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->