### PR TITLE
fix(fiservemea): enmascarar la API Key en los headers, salía en texto…

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiservemea.rs
@@ -442,7 +442,15 @@ where
                     .into(),
             ),
             ("Client-Request-Id".to_string(), client_request_id.into()),
-            (headers::API_KEY.to_string(), auth.api_key.expose().into()),
+            // `into_masked()` y no `into()`: el logger imprime el Debug de
+            // `Maskable<String>`, así que un valor sin enmascarar sale en texto plano al
+            // log. La API Key de Fiserv es una credencial y no debe quedar ahí (se
+            // verificó en logs de producción: aparecía completa junto al resto de los
+            // headers, mientras la firma HMAC sí salía enmascarada).
+            (
+                headers::API_KEY.to_string(),
+                auth.api_key.expose().into_masked(),
+            ),
             (headers::TIMESTAMP.to_string(), timestamp.to_string().into()),
             (headers::MESSAGE_SIGNATURE.to_string(), hmac.into_masked()),
         ];


### PR DESCRIPTION
… plano al log

`build_headers` armaba el header `API-KEY` con `.into()` en vez de `.into_masked()`. El logger imprime el `Debug` de `Maskable<String>`, así que la credencial salía completa al log junto al resto de los headers. Verificado en logs de producción: la API Key aparecía en texto plano mientras el `Message-Signature` sí salía enmascarado.

El otro lugar que arma el mismo header (`signed_headers_for_payload`, usado por el 3DS) ya lo hacía bien; payway y mercadopago también. Este era el único caso.

Alcance de la exposición: sólo la API Key (la pública, que viaja en el header). El `api_secret` que firma el HMAC nunca se loggeaba, así que la key sola no permite firmar requests.

176/176 tests, clippy limpio.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Fiserv MENA header construction to apply `.into_masked()` to the `API-KEY` value.
- Prevented the public API key from appearing in plaintext in logs.
- Preserved existing masking for `Message-Signature` and 3DS headers.
- No changes to the API contract, database schema, or application configuration.
- No architectural or performance impact. The change only modifies credential representation during header construction.
- The `api_secret` remains used for HMAC signing and was not exposed in logs.
- All 176 tests pass, and Clippy reports no issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->